### PR TITLE
Add a Dockerfile for running locally

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -29,3 +29,4 @@ LICENSE
 .env
 .env.*
 
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,7 @@ EXPOSE 8787
 # Wrangler expects secrets in .dev.vars file, not shell env vars
 RUN printf '#!/bin/sh\n\
     # Generate .dev.vars from environment variables\n\
+    : > .dev.vars\n\
     env | grep -E "^(CLOUDFLARE_|CF_)" | while read -r line; do\n\
     echo "$line" >> .dev.vars\n\
     done\n\


### PR DESCRIPTION
Took a shot at vibe-coding a Dockerfile to run the exporter locally. It uses Bun to install dependencies, then the latest Node LTS to run the exporter via `wrangler dev`. Had to do iterate a few times to get the API Token passed to wrangler properly.

Feedback welcome!