### PR TITLE
fix: align metric refresh alarms to interval boundaries to prevent drift

### DIFF
--- a/src/durable-objects/MetricExporter.ts
+++ b/src/durable-objects/MetricExporter.ts
@@ -354,9 +354,15 @@ export class MetricExporter extends DurableObject<Env> {
 	 */
 	private async scheduleNextAlarm(config: ResolvedConfig): Promise<void> {
 		const intervalMs = config.metricRefreshIntervalSeconds * 1000;
-		// Jitter: 1-5s fixed (tighter clustering for time range alignment)
+
+		// Get the start of the current minute interval
+		const now = Date.now();
+		const startOfInterval = Math.floor(now / intervalMs) * intervalMs;
+
+		// Add the jitter (1-5s) to the NEXT interval start
+		// This ensures we always fire at ":01-05" of every interval
 		const jitter = 1000 + Math.random() * 4000;
-		const nextAlarm = Date.now() + intervalMs + jitter;
+		const nextAlarm = startOfInterval + intervalMs + jitter;
 
 		await this.ctx.storage.setAlarm(nextAlarm);
 	}


### PR DESCRIPTION
## Background 

This PR fixes an issue where the exporter would occasionally skip minutes in its data collection.

Alarms were being scheduled relative to the completion time of the previous refresh 
`Date.now() + 60s + jitter` 

depending on how long the network call will take to the Cloudflare metrics api, the total cycle time was always greater than 60 seconds (e.g. 63-67 seconds). This drift eventually pushed the next alarm past a minute boundary, causing getTimeRange() (which rounds to the nearest minute) to skip a data bucket entirely. This would show up as a flat line in prometheus counters (depending in the scrape interval and minute resolution, see attached graphs)

the fix aligns the alarm schedules to fixed interval boundaries which is at the top of the minute.
the next alarm time is now calculated relative to the start of the interval 
`floor(now / 60) * 60 + 60)` 

With fix, the updates are uniform
<img width="1844" height="707" alt="Screenshot 2025-12-19 at 12 05 40" src="https://github.com/user-attachments/assets/07a74bfd-6b96-45d3-982b-58496494d4ad" />

Without the fix, you end up skipping a updates which causes the scrape to fetch a stale value for a particular minute interval,  
<img width="1864" height="484" alt="Screenshot 2025-12-19 at 12 08 27" src="https://github.com/user-attachments/assets/6cca17a2-55c2-4529-a35e-775041d9de4b" />

