### PR TITLE
Fix token link

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Set in `wrangler.jsonc` or via `wrangler secret put`:
 
 ### Creating an API Token
 
-**Quick setup**: [Create token with pre-filled permissions](https://dash.cloudflare.com/profile/api-tokens?permissionGroupKeys=%5B%7B%22key%22%3A%22zone_analytics%22%2C%22type%22%3A%22read%22%7D%2C%7B%22key%22%3A%22account_analytics%22%2C%22type%22%3A%22read%22%7D%2C%7B%22key%22%3A%22workers_scripts%22%2C%22type%22%3A%22read%22%7D%2C%7B%22key%22%3A%22ssl_certificates%22%2C%22type%22%3A%22read%22%7D%2C%7B%22key%22%3A%22firewall_services%22%2C%22type%22%3A%22read%22%7D%2C%7B%22key%22%3A%22load_balancers%22%2C%22type%22%3A%22read%22%7D%2C%7B%22key%22%3A%22logpush%22%2C%22type%22%3A%22read%22%7D%5D&name=Cloudflare%20Prometheus%20Exporter)
+**Quick setup**: [Create token with pre-filled permissions](https://dash.cloudflare.com/profile/api-tokens?permissionGroupKeys=%5B%7B%22key%22%3A%22analytics%22%2C%22type%22%3A%22read%22%7D%2C%7B%22key%22%3A%22account_analytics%22%2C%22type%22%3A%22read%22%7D%2C%7B%22key%22%3A%22workers_scripts%22%2C%22type%22%3A%22read%22%7D%2C%7B%22key%22%3A%22ssl_and_certificates%22%2C%22type%22%3A%22read%22%7D%2C%7B%22key%22%3A%22firewall_services%22%2C%22type%22%3A%22read%22%7D%2C%7B%22key%22%3A%22load_balancers%22%2C%22type%22%3A%22read%22%7D%2C%7B%22key%22%3A%22account_logs%22%2C%22type%22%3A%22read%22%7D%2C%7B%22key%22%3A%22magic_transit%22%2C%22type%22%3A%22read%22%7D%5D&name=Cloudflare%20Prometheus%20Exporter)
 
 **Manual setup**:
 
@@ -78,7 +78,7 @@ Set in `wrangler.jsonc` or via `wrangler secret put`:
 | Zone > SSL and Certificates | Read | Optional |
 | Zone > Firewall Services | Read | Optional |
 | Zone > Load Balancers | Read | Optional |
-| Account > Logpush | Read | Optional |
+| Account > Logs | Read | Optional |
 | Account > Magic Transit | Read | Optional |
 
 ## Endpoints


### PR DESCRIPTION
Hi! Quick fix for Creating token with pre-filled permissions via link.

Clicking the link now gives you token with all required and optional permissions:

<img width="2364" height="1282" alt="CleanShot 2025-12-19 at 13 58 32@2x" src="https://github.com/user-attachments/assets/5d7973ba-4245-4d13-a8e7-9d2ec63fb60e" />

Instead of previous:

<img width="2406" height="1520" alt="CleanShot 2025-12-19 at 13 59 50@2x" src="https://github.com/user-attachments/assets/fa2feb62-cdac-4f5c-8f72-02ee1b82c2a4" />

Fixed typo `Logpush` -> `Logs` in the table to match the actual permission name.


Happy to adjust if needed. 🙏 