### PR TITLE
feat: add status dimension in worker metrics

### DIFF
--- a/src/cloudflare/client.ts
+++ b/src/cloudflare/client.ts
@@ -528,9 +528,11 @@ export class CloudflareMetricsClient {
 		for (const accountData of result.data?.viewer?.accounts ?? []) {
 			for (const worker of accountData.workersInvocationsAdaptive ?? []) {
 				const scriptName = worker.dimensions?.scriptName ?? "unknown";
+				const status = worker.dimensions?.status ?? "unknown";
 				const baseLabels = {
 					script_name: scriptName,
 					account: normalizedAccount,
+					status: status,
 				};
 
 				requestsMetric.values.push({


### PR DESCRIPTION
## What
Adding the status as part of the worker metrics.

## Why

Without status, worker metrics aggregate all invocation outcomes together. This causes misleading data because failed/disconnected requests have vastly different performance characteristics than successful ones.

If we use `cloudflare_worker_cpu_time_seconds` to determine how much time the worker is taking, currently, the data can be skewed as `success` status takes far less time than `clientDisconnected` status.

Without the proper slicing/filtering of the data, it becomes difficult to measure and alert based on the above metric.


## Tesing

This should be a completely safe change, especially since we are already fetching this value from the Cloudflare GraphQL API: https://github.com/cloudflare/cloudflare-prometheus-exporter/blob/ca74cdbed9189c89d2581d212ca7262df3f5d500/src/cloudflare/gql/queries.ts#L373-L388


However, I did run it against a Cloudflare account using:

 ```bash
   echo "CLOUDFLARE_API_TOKEN=<TOKEN>" > .dev.vars
   npm install
   npm run dev
 ```
 
 
 post which using going to `http://localhost:8787/metrics` I could see:
 
 ```
 cloudflare_worker_requests_total{script_name="redacted",account="redacted",status="success"} 6
cloudflare_worker_requests_total{script_name="redacted",account="redacted",status="clientDisconnected"} 8
...

cloudflare_worker_cpu_time_seconds{script_name="redacted",account="redacted",status="success",quantile="P999"} 0.049446

cloudflare_worker_cpu_time_seconds{script_name="redacted",account="redacted",status="clientDisconnected",quantile="P999"} 0.055794

```