### PR TITLE
feat: zone chunking for accounts with >10 zones

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,6 +104,6 @@ bun run cf-typegen   # Regenerate worker-configuration.d.ts
 
 **Docker:** For local Prometheus scraping only, not production deployment
 
-**Rate limiting:** `CF_API_RATE_LIMITER` binding (40 req/10s) - applied to Cloudflare API calls
+**Rate limiting:** `CF_API_RATE_LIMITER` binding (200 req/10s) - shared across all DOs in worker. Rough budget: ~160 req/60s per 50-zone account (incl REST); ~7 such accounts can saturate.
 
 **Dual config:** wrangler.jsonc `vars` + optional env vars + KV runtime overrides

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Export Cloudflare metrics to Prometheus. Built on Cloudflare Workers with Durabl
 - **Cloudflare Workers** - serverless edge deployment
 - **Durable Objects** - stateful counter accumulation for proper Prometheus semantics
 - **Background refresh** - alarms fetch data every 60s; scrapes return cached data instantly
-- **Rate limiting** - 40 req/10s with exponential backoff
+- **Rate limiting** - 200 req/10s with exponential backoff
 - **Multi-account** - automatically discovers and exports all accessible accounts/zones
 - **Runtime config API** - change settings without redeployment via REST endpoints
 - **Configurable** - zone filtering, metric denylist, label exclusion, custom metrics path, and more
@@ -429,7 +429,7 @@ For mixed accounts (enterprise + free zones), only free zones are skipped—paid
 │  │  - urql Client (GraphQL)                                                │   │
 │  │  - Cloudflare SDK (REST)                                                │   │
 │  │  - DataLoader: firewallRulesLoader (batches Promise.all calls)          │   │
-│  │  - Global Rate limiter: 40 req/10s with exponential backoff             │   │
+│  │  - Global Rate limiter: 200 req/10s with exponential backoff            │   │
 │  └─────────────────────────────────────────────────────────────────────────┘   │
 └────────────────────────────────────────────────────────────────────────────────┘
 ```

--- a/src/cloudflare/client.ts
+++ b/src/cloudflare/client.ts
@@ -2730,7 +2730,7 @@ export function getCloudflareMetricsClient(env: Env): CloudflareMetricsClient {
 	const logger = createLogger("cf_client_singleton", loggerConfig);
 
 	logger.info("Creating CloudflareMetricsClient singleton", {
-		rate_limit: "40/10s",
+		rate_limit: "200/10s",
 		log_level: loggerConfig.level,
 		log_format: loggerConfig.format,
 	});

--- a/src/durable-objects/MetricExporter.ts
+++ b/src/durable-objects/MetricExporter.ts
@@ -7,7 +7,11 @@ import {
 import { isPaidTierGraphQLQuery } from "../cloudflare/queries";
 import { parseCommaSeparated, partitionZonesByTier } from "../lib/filters";
 import { createLogger, type Logger } from "../lib/logger";
-import type { MetricDefinition, MetricValue } from "../lib/metrics";
+import {
+	type MetricDefinition,
+	type MetricValue,
+	mergeMetricDefinitions,
+} from "../lib/metrics";
 import { getConfig, type ResolvedConfig } from "../lib/runtime-config";
 import { getTimeRange, metricKey } from "../lib/time";
 import {
@@ -455,15 +459,54 @@ export class MetricExporter extends DurableObject<Env> {
 				}
 			}
 
-			const zoneIds = zonesToQuery.map((z) => z.id);
-			return client.getZoneMetrics(
-				queryName,
-				zoneIds,
-				zonesToQuery,
-				firewallRules,
-				timeRange,
-				hostMetricsAllowlist,
-			);
+			// Cloudflare GraphQL API limits queries to 10 zones (zonesHardLimit).
+			// Chunk zones and merge results to support accounts with >10 zones.
+			const ZONES_PER_CHUNK = 10;
+
+			if (zonesToQuery.length <= ZONES_PER_CHUNK) {
+				const zoneIds = zonesToQuery.map((z) => z.id);
+				return client.getZoneMetrics(
+					queryName,
+					zoneIds,
+					zonesToQuery,
+					firewallRules,
+					timeRange,
+					hostMetricsAllowlist,
+				);
+			}
+
+			const chunkResults: MetricDefinition[][] = [];
+			for (let i = 0; i < zonesToQuery.length; i += ZONES_PER_CHUNK) {
+				const chunkZones = zonesToQuery.slice(i, i + ZONES_PER_CHUNK);
+				const chunkIds = chunkZones.map((z) => z.id);
+
+				try {
+					const metrics = await client.getZoneMetrics(
+						queryName,
+						chunkIds,
+						chunkZones,
+						firewallRules,
+						timeRange,
+						hostMetricsAllowlist,
+					);
+					chunkResults.push(metrics);
+				} catch (error) {
+					// Log and continue — partial results from other chunks are still valuable.
+					// Missing zones don't increment their counters this cycle;
+					// processCounters() accumulates per (name, labels) key so existing
+					// counter values are preserved. Next alarm retries all chunks.
+					logger.error("Zone chunk query failed", {
+						query: queryName,
+						chunk_index: Math.floor(i / ZONES_PER_CHUNK),
+						chunk_size: chunkZones.length,
+						total_zones: zonesToQuery.length,
+						failed_zones: chunkZones.map((z) => z.name),
+						error: error instanceof Error ? error.message : String(error),
+					});
+				}
+			}
+
+			return mergeMetricDefinitions(...chunkResults);
 		}
 
 		// Unknown query - should not happen if IDs are constructed correctly

--- a/src/lib/metrics.ts
+++ b/src/lib/metrics.ts
@@ -40,3 +40,38 @@ export const MetricDefinitionSchema = z.object({
 	type: MetricTypeSchema,
 	values: z.array(MetricValueSchema),
 });
+
+/**
+ * Merge multiple MetricDefinition arrays by metric name.
+ * Metrics with the same name have their values concatenated.
+ * Used when zone-chunked queries produce partial results that need recombining.
+ *
+ * @param arrays MetricDefinition arrays to merge.
+ * @returns Single merged array with values combined per metric name.
+ */
+export function mergeMetricDefinitions(
+	...arrays: MetricDefinition[][]
+): MetricDefinition[] {
+	if (arrays.length === 0) return [];
+
+	const first = arrays[0];
+	if (arrays.length === 1 && first !== undefined) return first;
+
+	const byName = new Map<string, MetricDefinition>();
+	for (const metrics of arrays) {
+		for (const m of metrics) {
+			const existing = byName.get(m.name);
+			if (existing) {
+				existing.values.push(...m.values);
+			} else {
+				byName.set(m.name, {
+					name: m.name,
+					help: m.help,
+					type: m.type,
+					values: [...m.values],
+				});
+			}
+		}
+	}
+	return Array.from(byName.values());
+}

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -48,7 +48,7 @@
 			"name": "CF_API_RATE_LIMITER",
 			"namespace_id": "1",
 			"simple": {
-				"limit": 40,
+				"limit": 200,
 				"period": 10
 			}
 		}


### PR DESCRIPTION
## Summary

- Chunk zone IDs into batches of ≤10 per GraphQL query to respect the `zonesHardLimit` in the GraphQL API
- Merge chunked results via new `mergeMetricDefinitions()` utility
- Bump self-imposed rate limit from 40→200 req/10s to accommodate increased request volume from chunking

## Problem

Cloudflare's GraphQL API hard-limits queries to 10 zones per `zoneTag_in` filter. Customers with >10 zones (e.g., Workday with ~19 accounts) get `"too many zones requested"` errors. See [#11](https://github.com/cloudflare/cloudflare-prometheus-exporter/issues/11).

## Changes

**`src/lib/metrics.ts`** — `mergeMetricDefinitions()`: merges `MetricDefinition[]` arrays by name with fast paths for 0/1 inputs. First insert copies values array for mutation safety; subsequent inserts push onto the owned copy.

**`src/durable-objects/MetricExporter.ts`** — `fetchAccountScopedMetrics()`: replaces single `getZoneMetrics()` call with chunked loop. Fast path for ≤10 zones (no overhead). Sequential chunk execution to avoid rate limiter spikes. Per-chunk try/catch with partial result merge — failed chunks log and continue; counter values are preserved (flat line, not reset).

**`wrangler.jsonc`** — Rate limit bumped to 200/10s. Math: 50 zones → 5 chunks × 13 zone queries = 65 GQL calls + REST calls ≈ 160/60s per account. 200/10s = 1200/60s budget handles ~7 such accounts.

**Docs** — Updated rate limit references in `AGENTS.md`, `README.md` (2 spots), `client.ts` log string.

## Design Decisions

- **Chunk at DO layer** (MetricExporter), not client — client stays a pure query executor
- **Sequential, not parallel** — 13 MetricExporter DOs already run concurrently per account; parallel chunks within each would compound bursts
- **Partial failure tolerance** — `processCounters()` accumulates per `(name, labels)` key, so missing zones = flat counter (not reset). Gauges from failed chunks disappear transiently.
- **`ZONES_PER_CHUNK = 10` hardcoded** — matches server-side `zonesHardLimit`, not a tuning knob

Closes #11