### PR TITLE
feat: add Cloudflare Images storage metrics

### DIFF
--- a/src/cloudflare/client.ts
+++ b/src/cloudflare/client.ts
@@ -533,6 +533,8 @@ export class CloudflareMetricsClient {
 					normalizedAccount,
 					timeRange,
 				);
+			case "images":
+				return this.getImagesMetrics(accountId, normalizedAccount);
 			default: {
 				const _exhaustive: never = query;
 				throw new Error(`Unknown account metric query: ${_exhaustive}`);
@@ -1455,6 +1457,49 @@ export class CloudflareMetricsClient {
 		return [segments, bitRate, gopDuration, uploadRatio].filter(
 			(m) => m.values.length > 0,
 		);
+	}
+
+	/**
+	 * Fetches Cloudflare Images storage metrics (current count and allowed limit).
+	 *
+	 * @param accountId Cloudflare account ID.
+	 * @param normalizedAccount Normalized account name for labels.
+	 * @returns Images count metrics.
+	 */
+	private async getImagesMetrics(
+		accountId: string,
+		normalizedAccount: string,
+	): Promise<MetricDefinition[]> {
+		const countCurrent: MetricDefinition = {
+			name: "cloudflare_images_count_current",
+			help: "Current number of images stored in Cloudflare Images",
+			type: "gauge",
+			values: [],
+		};
+		const countAllowed: MetricDefinition = {
+			name: "cloudflare_images_count_allowed",
+			help: "Maximum number of images allowed by the account plan",
+			type: "gauge",
+			values: [],
+		};
+
+		try {
+			const response = await this.api.images.v1.stats.get({
+				account_id: accountId,
+			});
+			const labels = { account: normalizedAccount };
+			countCurrent.values.push({ labels, value: response.count?.current ?? 0 });
+			countAllowed.values.push({ labels, value: response.count?.allowed ?? 0 });
+		} catch (error) {
+			const msg = error instanceof Error ? error.message : String(error);
+			this.logger.error("Failed to fetch Images stats", {
+				account_id: accountId,
+				error: msg,
+			});
+			return [];
+		}
+
+		return [countCurrent, countAllowed].filter((m) => m.values.length > 0);
 	}
 
 	/**

--- a/src/cloudflare/queries.ts
+++ b/src/cloudflare/queries.ts
@@ -15,6 +15,7 @@ export const MetricQueryNameSchema = z.enum([
 	"network-analytics",
 	"stream-video-playback",
 	"stream-live-inputs",
+	"images",
 	// Zone-level
 	"http-metrics",
 	"adaptive-metrics",
@@ -51,6 +52,7 @@ export const ACCOUNT_LEVEL_QUERIES = [
 	"network-analytics",
 	"stream-video-playback",
 	"stream-live-inputs",
+	"images",
 ] as const;
 
 /**


### PR DESCRIPTION
## Summary

- Adds `cloudflare_images_count_current` and `cloudflare_images_count_allowed` gauges via the Cloudflare Images v1 stats REST endpoint (`GET /accounts/{account_id}/images/v1/stats`)
- Registers `images` as a pure account-level query (no zone context needed)

Closes #27

## Metrics added

| Metric | Type | Description |
|--------|------|-------------|
| `cloudflare_images_count_current` | gauge | Current number of images stored |
| `cloudflare_images_count_allowed` | gauge | Maximum images allowed by plan |

Labels: `account`

## Required token permission

`Cloudflare Images:Read` at the account level (already listed in the README's token scopes).