### PR TITLE
fix: coerce env vars for metrics client

### DIFF
--- a/src/cloudflare/client.ts
+++ b/src/cloudflare/client.ts
@@ -11,6 +11,7 @@ import {
 	type LoggerConfig,
 } from "../lib/logger";
 import type { MetricDefinition } from "../lib/metrics";
+import { getEnvDefaults } from "../lib/runtime-config";
 import type {
 	Account,
 	LoadBalancerPool,
@@ -3444,11 +3445,15 @@ export function getCloudflareMetricsClient(env: Env): CloudflareMetricsClient {
 
 	const loggerConfig = configFromEnv(env);
 	const logger = createLogger("cf_client_singleton", loggerConfig);
+	const defaults = getEnvDefaults(env);
 
 	logger.info("Creating CloudflareMetricsClient singleton", {
 		rate_limit: "200/10s",
 		log_level: loggerConfig.level,
 		log_format: loggerConfig.format,
+		query_limit: defaults.queryLimit,
+		scrape_delay_seconds: defaults.scrapeDelaySeconds,
+		time_window_seconds: defaults.timeWindowSeconds,
 	});
 
 	const rateLimitedFetch = createRateLimitedFetch(
@@ -3458,9 +3463,9 @@ export function getCloudflareMetricsClient(env: Env): CloudflareMetricsClient {
 
 	const client = new CloudflareMetricsClient({
 		apiToken: env.CLOUDFLARE_API_TOKEN,
-		scrapeDelaySeconds: env.SCRAPE_DELAY_SECONDS,
-		timeWindowSeconds: env.TIME_WINDOW_SECONDS,
-		queryLimit: env.QUERY_LIMIT,
+		scrapeDelaySeconds: defaults.scrapeDelaySeconds,
+		timeWindowSeconds: defaults.timeWindowSeconds,
+		queryLimit: defaults.queryLimit,
 		loggerConfig,
 		fetch: rateLimitedFetch,
 	});


### PR DESCRIPTION
## Summary
- Coerce Worker env defaults before constructing the Cloudflare metrics client
- Avoid passing Terraform `plain_text` string bindings as GraphQL numeric variables
- Add startup log fields for the effective numeric config used by the singleton client

## Context
Terraform deployments provide Worker `plain_text` bindings as strings. The metrics client previously consumed `QUERY_LIMIT`, `SCRAPE_DELAY_SECONDS`, and `TIME_WINDOW_SECONDS` directly from env, which can cause GraphQL-backed metric queries to receive string values where Ints are expected. REST-backed metrics can continue to work, matching the minimal-metrics symptom in ESCALATION-1456.

## Validation
- `bunx tsc --noEmit`
- `bunx biome check src worker-configuration.d.ts wrangler.jsonc README.md package.json tsconfig.json`

Note: full `bun run check` is currently affected locally by untracked Pi MCP files under `.pi/`, not by source files.
