### PR TITLE
feat: add custom hostname SSL status metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,6 +452,14 @@ All hostname metrics are **gauge snapshots** of the **last completed minute**, d
 |--------|------|--------|
 | `cloudflare_zone_certificate_validation_status` | gauge | zone, type, issuer, status |
 
+### Custom Hostname SSL Status Metrics
+
+| Metric | Type | Labels |
+|--------|------|--------|
+| `cloudflare_zone_custom_hostname_ssl_status_count` | gauge | zone, ssl_status, certificate_authority |
+
+Tracks the number of custom hostnames (Cloudflare for SaaS) grouped by SSL provisioning status and certificate authority. Non-active statuses (`pending_validation`, `pending_issuance`, `pending_deployment`, `validation_timed_out`, `deleted`, `initializing`) are queried individually to minimize API calls. Active count is inferred from the total. Requires **SSL and Certificates:Read** API token scope.
+
 ### Exporter Info Metrics
 
 | Metric | Type | Labels |
@@ -471,6 +479,7 @@ Zones on Cloudflare's Free plan don't have access to the GraphQL Analytics API. 
 **Free tier zones still export:**
 - `cloudflare_zone_certificate_validation_status` (SSL certificates)
 - `cloudflare_zone_lb_origin_weight` (Load balancer weights, if configured)
+- `cloudflare_zone_custom_hostname_ssl_status_count` (Custom hostname SSL status)
 
 **Monitor skipped zones:**
 ```

--- a/src/cloudflare/client.ts
+++ b/src/cloudflare/client.ts
@@ -1526,6 +1526,8 @@ export class CloudflareMetricsClient {
 				return this.getSSLCertificateMetrics(zones);
 			case "lb-weight-metrics":
 				return this.getLbWeightMetrics(zones);
+			case "custom-hostname-ssl-status":
+				return this.getCustomHostnameSslStatusMetrics(zones);
 			default: {
 				const _exhaustive: never = query;
 				throw new Error(`Unknown zone metric query: ${_exhaustive}`);
@@ -3328,6 +3330,158 @@ export class CloudflareMetricsClient {
 		}
 
 		return certStatus.values.length > 0 ? [certStatus] : [];
+	}
+
+	/**
+	 * Fetches custom hostname SSL status counts for multiple zones.
+	 * Queries only non-active statuses to minimize API calls, then infers active count.
+	 */
+	private async getCustomHostnameSslStatusMetrics(
+		zones: Zone[],
+	): Promise<MetricDefinition[]> {
+		const results = await Promise.all(
+			zones.map((zone) =>
+				this.getCustomHostnameSslStatusMetricsForZone(zone).catch(() => {
+					this.logger.warn("Failed to fetch custom hostname SSL status", {
+						zone: zone.name,
+					});
+					return [] as MetricDefinition[];
+				}),
+			),
+		);
+		return results.flat();
+	}
+
+	/**
+	 * Fetches custom hostname SSL status counts for a single zone.
+	 * Queries non-active SSL statuses individually, infers active count from total.
+	 */
+	async getCustomHostnameSslStatusMetricsForZone(
+		zone: Zone,
+	): Promise<MetricDefinition[]> {
+		this.logger.info("Fetching custom hostname SSL status for zone", {
+			zone: zone.name,
+		});
+
+		const metric: MetricDefinition = {
+			name: "cloudflare_zone_custom_hostname_ssl_status_count",
+			help: "Number of custom hostnames by SSL status and certificate authority",
+			type: "gauge",
+			values: [],
+		};
+
+		const nonActiveStatuses = [
+			"pending_validation",
+			"pending_issuance",
+			"pending_deployment",
+			"validation_timed_out",
+			"deleted",
+			"initializing",
+		];
+
+		type ResultInfoWithTotal = { total_count?: number; page?: number; per_page?: number };
+
+		try {
+			// Get total count from first page of unfiltered request
+			const firstPage = await this.api.customHostnames.list({
+				zone_id: zone.id,
+				per_page: 1,
+			});
+			const totalCount = (firstPage.result_info as ResultInfoWithTotal)?.total_count ?? 0;
+
+			if (totalCount === 0) {
+				return [];
+			}
+
+			// Fetch counts for each non-active status
+			let nonActiveTotal = 0;
+			const caCounts: Record<string, Record<string, number>> = {};
+
+			for (const status of nonActiveStatuses) {
+				const response = await this.api.customHostnames.list({
+					zone_id: zone.id,
+					ssl: 1,
+					per_page: 50,
+					// @ts-expect-error -- ssl_status filter is supported but not in SDK types
+					ssl_status: status,
+				});
+
+				const statusCount = (response.result_info as ResultInfoWithTotal)?.total_count ?? 0;
+				if (statusCount === 0) continue;
+
+				// Count by CA from returned results
+				const caMap: Record<string, number> = {};
+				for (const hostname of response.result) {
+					const ssl = hostname.ssl as Record<string, unknown> | null;
+					const ca = (ssl?.certificate_authority as string) ?? "unknown";
+					caMap[ca] = (caMap[ca] ?? 0) + 1;
+				}
+
+				// If there are more results than the first page, paginate
+				if (statusCount > 50) {
+					let page = 2;
+					const totalPages = Math.ceil(statusCount / 50);
+					while (page <= totalPages) {
+						const nextPage = await this.api.customHostnames.list({
+							zone_id: zone.id,
+							ssl: 1,
+							per_page: 50,
+							page,
+							// @ts-expect-error -- ssl_status filter is supported but not in SDK types
+							ssl_status: status,
+						});
+						for (const hostname of nextPage.result) {
+							const ssl = hostname.ssl as Record<string, unknown> | null;
+							const ca = (ssl?.certificate_authority as string) ?? "unknown";
+							caMap[ca] = (caMap[ca] ?? 0) + 1;
+						}
+						page++;
+					}
+				}
+
+				nonActiveTotal += statusCount;
+
+				for (const [ca, count] of Object.entries(caMap)) {
+					if (!caCounts[status]) caCounts[status] = {};
+					caCounts[status][ca] = count;
+				}
+			}
+
+			// Emit non-active status metrics
+			for (const [status, cas] of Object.entries(caCounts)) {
+				for (const [ca, count] of Object.entries(cas)) {
+					metric.values.push({
+						labels: {
+							zone: zone.name,
+							ssl_status: status,
+							certificate_authority: ca,
+						},
+						value: count,
+					});
+				}
+			}
+
+			// Emit active count (total minus all non-active)
+			const activeCount = totalCount - nonActiveTotal;
+			if (activeCount > 0) {
+				metric.values.push({
+					labels: {
+						zone: zone.name,
+						ssl_status: "active",
+						certificate_authority: "all",
+					},
+					value: activeCount,
+				});
+			}
+		} catch (error) {
+			const msg = error instanceof Error ? error.message : String(error);
+			this.logger.warn("Failed to fetch custom hostname SSL status for zone", {
+				zone: zone.name,
+				error: msg,
+			});
+		}
+
+		return metric.values.length > 0 ? [metric] : [];
 	}
 
 	/**

--- a/src/cloudflare/queries.ts
+++ b/src/cloudflare/queries.ts
@@ -31,6 +31,7 @@ export const MetricQueryNameSchema = z.enum([
 	// REST API
 	"ssl-certificates",
 	"lb-weight-metrics",
+	"custom-hostname-ssl-status",
 ]);
 
 /**
@@ -76,6 +77,7 @@ export const ZONE_LEVEL_QUERIES = [
 	"hostname-http-metrics",
 	"ssl-certificates",
 	"lb-weight-metrics",
+	"custom-hostname-ssl-status",
 ] as const;
 
 /**

--- a/src/durable-objects/MetricExporter.ts
+++ b/src/durable-objects/MetricExporter.ts
@@ -541,6 +541,8 @@ export class MetricExporter extends DurableObject<Env> {
 				return client.getSSLCertificateMetricsForZone(zoneMetadata);
 			case "lb-weight-metrics":
 				return client.getLbWeightMetricsForZone(zoneMetadata);
+			case "custom-hostname-ssl-status":
+				return client.getCustomHostnameSslStatusMetricsForZone(zoneMetadata);
 			default:
 				console.error("Unknown zone-scoped query", { queryName });
 				return [];


### PR DESCRIPTION
## Summary

- Adds `cloudflare_zone_custom_hostname_ssl_status_count` gauge metric tracking custom hostnames (Cloudflare for SaaS) grouped by SSL provisioning status and certificate authority

- Uses the REST API collector pattern (like `ssl-certificates`), querying only non-active SSL statuses individually to minimize API calls; active count is inferred from total

- Labels: `zone`, `ssl_status`, `certificate_authority`

- Tracked statuses: `active`, `pending_validation`, `pending_issuance`, `pending_deployment`, `validation_timed_out`, `deleted`, `initializing`

## Motivation

Cloudflare for SaaS users managing thousands of custom hostnames currently have no Prometheus-level visibility into SSL provisioning failures. This metric enables alerting on `validation_timed_out` and `pending_validation` spikes — particularly important when hitting Let's Encrypt rate limits or when customer DNS changes break DCV.

## Files changed

- `src/cloudflare/queries.ts` — Added `"custom-hostname-ssl-status"` to enum + zone-level queries

- `src/cloudflare/client.ts` — Added `getCustomHostnameSslStatusMetrics()` (batched) and `getCustomHostnameSslStatusMetricsForZone()` (single zone) collectors

- `src/durable-objects/MetricExporter.ts` — Added case in `fetchZoneScopedMetrics` switch

- `README.md` — Documented new metric, labels, and scope requirements

## API usage

Per zone per scrape: 1 call for total count + 1 call per non-active status (6 statuses). Zones with all-healthy SSL = 7 calls. Only statuses with results paginate further. Requires existing **SSL and Certificates:Read** scope.

## Test plan

- [ ] Verify TypeScript compiles cleanly (`npx tsc --noEmit`)

- [ ] Deploy to staging and confirm metric appears in `/metrics` output for zones with custom hostnames

- [ ] Verify non-active status counts match Cloudflare dashboard

- [ ] Confirm zones with no custom hostnames emit no metric (no empty series)

- [ ] Load test: verify API call volume is acceptable for accounts with 10+ zones