### PR TITLE
fix: bound metric exporter state growth

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,31 @@
+name: Check
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Install Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Lint and format check
+        run: bun run check
+
+      - name: Typecheck
+        run: bun run typecheck
+
+      - name: Test
+        run: bun run test

--- a/README.md
+++ b/README.md
@@ -697,8 +697,9 @@ For mixed accounts (enterprise + free zones), only free zones are skipped—paid
 ```
 
 Counter series are retained for five missed refreshes before being pruned. Metric
-exporter snapshots are persisted in bounded chunks, and product queries denied by
-Cloudflare are retried hourly instead of every refresh interval.
+exporter snapshots are persisted in bounded chunks, product queries denied by
+Cloudflare are retried hourly, and unexpected alarm failures schedule a recovery
+alarm so metric refreshes cannot silently stop.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -696,12 +696,18 @@ For mixed accounts (enterprise + free zones), only free zones are skipped—paid
 └────────────────────────────────────────────────────────────────────────┘
 ```
 
+Counter series are retained for five missed refreshes before being pruned. Metric
+exporter snapshots are persisted in bounded chunks, and product queries denied by
+Cloudflare are retried hourly instead of every refresh interval.
+
 ## Development
 
 ```bash
 bun install          # Install dependencies
 bun run dev          # Run locally (port 8787)
 bun run check        # Lint + format check
+bun run test         # Run tests
+bun run typecheck    # Type-check without emitting files
 bun run deploy       # Deploy to Cloudflare
 ```
 

--- a/README.md
+++ b/README.md
@@ -697,9 +697,13 @@ For mixed accounts (enterprise + free zones), only free zones are skipped—paid
 ```
 
 Counter series are retained for five missed refreshes before being pruned. Metric
-exporter snapshots are persisted in bounded chunks, product queries denied by
-Cloudflare are retried hourly, and unexpected alarm failures schedule a recovery
-alarm so metric refreshes cannot silently stop.
+exporter snapshots are persisted in bounded chunks (with a 16 MiB total safety
+limit), product queries denied by Cloudflare are retried hourly, and unexpected
+alarm failures schedule a recovery alarm so metric refreshes cannot silently stop.
+
+Chunked snapshots retain the last unchunked state at the legacy storage key, but a
+rollback to a pre-chunking release cannot read the current chunked snapshot and may
+resume the original oversized-write failure. Prefer a forward fix after deployment.
 
 ## Development
 

--- a/bun.lock
+++ b/bun.lock
@@ -18,6 +18,7 @@
       "devDependencies": {
         "@biomejs/biome": "^2.3.8",
         "typescript": "^5.9.3",
+        "vitest": "^4.1.7",
         "wrangler": "^4.51.0",
       },
     },
@@ -61,7 +62,11 @@
 
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
 
-    "@emnapi/runtime": ["@emnapi/runtime@1.7.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-PVtJr5CmLwYAU9PZDMITZoR5iAOShYREoR45EyyLrbntV50mdePTgUn4AmOw90Ifcj+x2kRjdzr1HP3RrNiHGA=="],
+    "@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" } }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
+
+    "@emnapi/runtime": ["@emnapi/runtime@1.10.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA=="],
+
+    "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w=="],
 
     "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.4", "", { "os": "aix", "cpu": "ppc64" }, "sha512-1VCICWypeQKhVbE9oW/sJaAmjLxhVqacdkvPLEjwlttjfwENRSClS8EjBz0KzRyFSCPDIkuXW34Je/vk7zdB7Q=="],
 
@@ -161,21 +166,81 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.9", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.0.3", "@jridgewell/sourcemap-codec": "^1.4.10" } }, "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ=="],
 
+    "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.5", "", { "dependencies": { "@tybys/wasm-util": "^0.10.2" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q=="],
+
+    "@oxc-project/types": ["@oxc-project/types@0.133.0", "", {}, "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA=="],
+
     "@poppinss/colors": ["@poppinss/colors@4.1.5", "", { "dependencies": { "kleur": "^4.1.5" } }, "sha512-FvdDqtcRCtz6hThExcFOgW0cWX+xwSMWcRuQe5ZEb2m7cVQOAVZOIMt+/v9RxGiD9/OY16qJBXK4CVKWAPalBw=="],
 
     "@poppinss/dumper": ["@poppinss/dumper@0.6.5", "", { "dependencies": { "@poppinss/colors": "^4.1.5", "@sindresorhus/is": "^7.0.2", "supports-color": "^10.0.0" } }, "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw=="],
 
     "@poppinss/exception": ["@poppinss/exception@1.2.2", "", {}, "sha512-m7bpKCD4QMlFCjA/nKTs23fuvoVFoA83brRKmObCUNmi/9tVu8Ve3w4YQAnJu4q3Tjf5fr685HYIC/IA2zHRSg=="],
 
+    "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.3", "", { "os": "android", "cpu": "arm64" }, "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw=="],
+
+    "@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.0.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA=="],
+
+    "@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.0.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg=="],
+
+    "@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.0.3", "", { "os": "freebsd", "cpu": "x64" }, "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g=="],
+
+    "@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.0.3", "", { "os": "linux", "cpu": "arm" }, "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw=="],
+
+    "@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.0.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw=="],
+
+    "@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.0.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q=="],
+
+    "@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.0.3", "", { "os": "linux", "cpu": "ppc64" }, "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg=="],
+
+    "@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.0.3", "", { "os": "linux", "cpu": "s390x" }, "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg=="],
+
+    "@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.0.3", "", { "os": "linux", "cpu": "x64" }, "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg=="],
+
+    "@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.0.3", "", { "os": "linux", "cpu": "x64" }, "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow=="],
+
+    "@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.0.3", "", { "os": "none", "cpu": "arm64" }, "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg=="],
+
+    "@rolldown/binding-wasm32-wasi": ["@rolldown/binding-wasm32-wasi@1.0.3", "", { "dependencies": { "@emnapi/core": "1.10.0", "@emnapi/runtime": "1.10.0", "@napi-rs/wasm-runtime": "^1.1.4" }, "cpu": "none" }, "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg=="],
+
+    "@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.0.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g=="],
+
+    "@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.0.3", "", { "os": "win32", "cpu": "x64" }, "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA=="],
+
+    "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.1", "", {}, "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw=="],
+
     "@sindresorhus/is": ["@sindresorhus/is@7.1.1", "", {}, "sha512-rO92VvpgMc3kfiTjGT52LEtJ8Yc5kCWhZjLQ3LwlA4pSgPpQO7bVpYXParOD8Jwf+cVQECJo3yP/4I8aZtUQTQ=="],
 
     "@speed-highlight/core": ["@speed-highlight/core@1.2.12", "", {}, "sha512-uilwrK0Ygyri5dToHYdZSjcvpS2ZwX0w5aSt3GCEN9hrjxWCoeV4Z2DTXuxjwbntaLQIEEAlCeNQss5SoHvAEA=="],
+
+    "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
+
+    "@tybys/wasm-util": ["@tybys/wasm-util@0.10.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg=="],
+
+    "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
+
+    "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
+
+    "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
 
     "@types/node": ["@types/node@18.19.130", "", { "dependencies": { "undici-types": "~5.26.4" } }, "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg=="],
 
     "@types/node-fetch": ["@types/node-fetch@2.6.13", "", { "dependencies": { "@types/node": "*", "form-data": "^4.0.4" } }, "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw=="],
 
     "@urql/core": ["@urql/core@6.0.1", "", { "dependencies": { "@0no-co/graphql.web": "^1.0.13", "wonka": "^6.3.2" } }, "sha512-FZDiQk6jxbj5hixf2rEPv0jI+IZz0EqqGW8mJBEug68/zHTtT+f34guZDmyjJZyiWbj0vL165LoMr/TkeDHaug=="],
+
+    "@vitest/expect": ["@vitest/expect@4.1.9", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.9", "@vitest/utils": "4.1.9", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA=="],
+
+    "@vitest/mocker": ["@vitest/mocker@4.1.9", "", { "dependencies": { "@vitest/spy": "4.1.9", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw=="],
+
+    "@vitest/pretty-format": ["@vitest/pretty-format@4.1.9", "", { "dependencies": { "tinyrainbow": "^3.1.0" } }, "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A=="],
+
+    "@vitest/runner": ["@vitest/runner@4.1.9", "", { "dependencies": { "@vitest/utils": "4.1.9", "pathe": "^2.0.3" } }, "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg=="],
+
+    "@vitest/snapshot": ["@vitest/snapshot@4.1.9", "", { "dependencies": { "@vitest/pretty-format": "4.1.9", "@vitest/utils": "4.1.9", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA=="],
+
+    "@vitest/spy": ["@vitest/spy@4.1.9", "", {}, "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA=="],
+
+    "@vitest/utils": ["@vitest/utils@4.1.9", "", { "dependencies": { "@vitest/pretty-format": "4.1.9", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA=="],
 
     "abort-controller": ["abort-controller@3.0.0", "", { "dependencies": { "event-target-shim": "^5.0.0" } }, "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg=="],
 
@@ -185,11 +250,15 @@
 
     "agentkeepalive": ["agentkeepalive@4.6.0", "", { "dependencies": { "humanize-ms": "^1.2.1" } }, "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ=="],
 
+    "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
+
     "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
 
     "blake3-wasm": ["blake3-wasm@2.1.5", "", {}, "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g=="],
 
     "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
+
+    "chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
 
     "cloudflare": ["cloudflare@5.2.0", "", { "dependencies": { "@types/node": "^18.11.18", "@types/node-fetch": "^2.6.4", "abort-controller": "^3.0.0", "agentkeepalive": "^4.2.1", "form-data-encoder": "1.7.2", "formdata-node": "^4.3.2", "node-fetch": "^2.6.7" } }, "sha512-dVzqDpPFYR9ApEC9e+JJshFJZXcw4HzM8W+3DHzO5oy9+8rLC53G7x6fEf9A7/gSuSCxuvndzui5qJKftfIM9A=="],
 
@@ -204,6 +273,8 @@
     "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
 
     "consola": ["consola@3.4.2", "", {}, "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA=="],
+
+    "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
     "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
 
@@ -221,15 +292,23 @@
 
     "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
 
+    "es-module-lexer": ["es-module-lexer@2.1.0", "", {}, "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ=="],
+
     "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
 
     "es-set-tostringtag": ["es-set-tostringtag@2.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA=="],
 
     "esbuild": ["esbuild@0.25.4", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.4", "@esbuild/android-arm": "0.25.4", "@esbuild/android-arm64": "0.25.4", "@esbuild/android-x64": "0.25.4", "@esbuild/darwin-arm64": "0.25.4", "@esbuild/darwin-x64": "0.25.4", "@esbuild/freebsd-arm64": "0.25.4", "@esbuild/freebsd-x64": "0.25.4", "@esbuild/linux-arm": "0.25.4", "@esbuild/linux-arm64": "0.25.4", "@esbuild/linux-ia32": "0.25.4", "@esbuild/linux-loong64": "0.25.4", "@esbuild/linux-mips64el": "0.25.4", "@esbuild/linux-ppc64": "0.25.4", "@esbuild/linux-riscv64": "0.25.4", "@esbuild/linux-s390x": "0.25.4", "@esbuild/linux-x64": "0.25.4", "@esbuild/netbsd-arm64": "0.25.4", "@esbuild/netbsd-x64": "0.25.4", "@esbuild/openbsd-arm64": "0.25.4", "@esbuild/openbsd-x64": "0.25.4", "@esbuild/sunos-x64": "0.25.4", "@esbuild/win32-arm64": "0.25.4", "@esbuild/win32-ia32": "0.25.4", "@esbuild/win32-x64": "0.25.4" }, "bin": "bin/esbuild" }, "sha512-8pgjLUcUjcgDg+2Q4NYXnPbo/vncAY4UmyaCm0jZevERqCHZIaWwdJHkf8XQtu4AxSKCdvrUbT0XUr1IdZzI8Q=="],
 
+    "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
+
     "event-target-shim": ["event-target-shim@5.0.1", "", {}, "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="],
 
     "exit-hook": ["exit-hook@2.2.1", "", {}, "sha512-eNTPlAD67BmP31LDINZ3U7HSF8l57TxOY2PmBJ1shpCvpnxBF93mWCE8YHBnXs8qiUZJc9WDcWIeC3a2HIAMfw=="],
+
+    "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
+
+    "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
     "form-data": ["form-data@4.0.5", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.12" } }, "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w=="],
 
@@ -269,6 +348,32 @@
 
     "kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
 
+    "lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
+
+    "lightningcss-android-arm64": ["lightningcss-android-arm64@1.32.0", "", { "os": "android", "cpu": "arm64" }, "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg=="],
+
+    "lightningcss-darwin-arm64": ["lightningcss-darwin-arm64@1.32.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ=="],
+
+    "lightningcss-darwin-x64": ["lightningcss-darwin-x64@1.32.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w=="],
+
+    "lightningcss-freebsd-x64": ["lightningcss-freebsd-x64@1.32.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig=="],
+
+    "lightningcss-linux-arm-gnueabihf": ["lightningcss-linux-arm-gnueabihf@1.32.0", "", { "os": "linux", "cpu": "arm" }, "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw=="],
+
+    "lightningcss-linux-arm64-gnu": ["lightningcss-linux-arm64-gnu@1.32.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ=="],
+
+    "lightningcss-linux-arm64-musl": ["lightningcss-linux-arm64-musl@1.32.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg=="],
+
+    "lightningcss-linux-x64-gnu": ["lightningcss-linux-x64-gnu@1.32.0", "", { "os": "linux", "cpu": "x64" }, "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA=="],
+
+    "lightningcss-linux-x64-musl": ["lightningcss-linux-x64-musl@1.32.0", "", { "os": "linux", "cpu": "x64" }, "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg=="],
+
+    "lightningcss-win32-arm64-msvc": ["lightningcss-win32-arm64-msvc@1.32.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw=="],
+
+    "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
+
+    "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 
     "mime": ["mime@3.0.0", "", { "bin": "cli.js" }, "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A=="],
@@ -281,23 +386,51 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
+    "nanoid": ["nanoid@3.3.12", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ=="],
+
     "node-domexception": ["node-domexception@1.0.0", "", {}, "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="],
 
     "node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
+
+    "obug": ["obug@2.1.3", "", {}, "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg=="],
 
     "path-to-regexp": ["path-to-regexp@6.3.0", "", {}, "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ=="],
 
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
+    "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
+
+    "postcss": ["postcss@8.5.15", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A=="],
+
+    "rolldown": ["rolldown@1.0.3", "", { "dependencies": { "@oxc-project/types": "=0.133.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.3", "@rolldown/binding-darwin-arm64": "1.0.3", "@rolldown/binding-darwin-x64": "1.0.3", "@rolldown/binding-freebsd-x64": "1.0.3", "@rolldown/binding-linux-arm-gnueabihf": "1.0.3", "@rolldown/binding-linux-arm64-gnu": "1.0.3", "@rolldown/binding-linux-arm64-musl": "1.0.3", "@rolldown/binding-linux-ppc64-gnu": "1.0.3", "@rolldown/binding-linux-s390x-gnu": "1.0.3", "@rolldown/binding-linux-x64-gnu": "1.0.3", "@rolldown/binding-linux-x64-musl": "1.0.3", "@rolldown/binding-openharmony-arm64": "1.0.3", "@rolldown/binding-wasm32-wasi": "1.0.3", "@rolldown/binding-win32-arm64-msvc": "1.0.3", "@rolldown/binding-win32-x64-msvc": "1.0.3" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g=="],
+
     "semver": ["semver@7.7.3", "", { "bin": "bin/semver.js" }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
 
     "sharp": ["sharp@0.33.5", "", { "dependencies": { "color": "^4.2.3", "detect-libc": "^2.0.3", "semver": "^7.6.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.33.5", "@img/sharp-darwin-x64": "0.33.5", "@img/sharp-libvips-darwin-arm64": "1.0.4", "@img/sharp-libvips-darwin-x64": "1.0.4", "@img/sharp-libvips-linux-arm": "1.0.5", "@img/sharp-libvips-linux-arm64": "1.0.4", "@img/sharp-libvips-linux-s390x": "1.0.4", "@img/sharp-libvips-linux-x64": "1.0.4", "@img/sharp-libvips-linuxmusl-arm64": "1.0.4", "@img/sharp-libvips-linuxmusl-x64": "1.0.4", "@img/sharp-linux-arm": "0.33.5", "@img/sharp-linux-arm64": "0.33.5", "@img/sharp-linux-s390x": "0.33.5", "@img/sharp-linux-x64": "0.33.5", "@img/sharp-linuxmusl-arm64": "0.33.5", "@img/sharp-linuxmusl-x64": "0.33.5", "@img/sharp-wasm32": "0.33.5", "@img/sharp-win32-ia32": "0.33.5", "@img/sharp-win32-x64": "0.33.5" } }, "sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw=="],
 
+    "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
+
     "simple-swizzle": ["simple-swizzle@0.2.4", "", { "dependencies": { "is-arrayish": "^0.3.1" } }, "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw=="],
+
+    "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
+
+    "std-env": ["std-env@4.1.0", "", {}, "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ=="],
 
     "stoppable": ["stoppable@1.1.0", "", {}, "sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw=="],
 
     "supports-color": ["supports-color@10.2.2", "", {}, "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g=="],
+
+    "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
+
+    "tinyexec": ["tinyexec@1.2.4", "", {}, "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg=="],
+
+    "tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
+
+    "tinyrainbow": ["tinyrainbow@3.1.0", "", {}, "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw=="],
 
     "tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
 
@@ -311,11 +444,17 @@
 
     "unenv": ["unenv@2.0.0-rc.24", "", { "dependencies": { "pathe": "^2.0.3" } }, "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw=="],
 
+    "vite": ["vite@8.0.16", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.15", "rolldown": "1.0.3", "tinyglobby": "^0.2.17" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.18", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw=="],
+
+    "vitest": ["vitest@4.1.9", "", { "dependencies": { "@vitest/expect": "4.1.9", "@vitest/mocker": "4.1.9", "@vitest/pretty-format": "4.1.9", "@vitest/runner": "4.1.9", "@vitest/snapshot": "4.1.9", "@vitest/spy": "4.1.9", "@vitest/utils": "4.1.9", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.9", "@vitest/browser-preview": "4.1.9", "@vitest/browser-webdriverio": "4.1.9", "@vitest/coverage-istanbul": "4.1.9", "@vitest/coverage-v8": "4.1.9", "@vitest/ui": "4.1.9", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "./vitest.mjs" } }, "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ=="],
+
     "web-streams-polyfill": ["web-streams-polyfill@4.0.0-beta.3", "", {}, "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug=="],
 
     "webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
 
     "whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
+
+    "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
 
     "wonka": ["wonka@6.3.5", "", {}, "sha512-SSil+ecw6B4/Dm7Pf2sAshKQ5hWFvfyGlfPbEd6A14dOH6VDjrmbY86u6nZvy9omGwwIPFR8V41+of1EezgoUw=="],
 
@@ -330,6 +469,8 @@
     "youch-core": ["youch-core@0.3.3", "", { "dependencies": { "@poppinss/exception": "^1.2.2", "error-stack-parser-es": "^1.0.5" } }, "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA=="],
 
     "zod": ["zod@4.1.13", "", {}, "sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig=="],
+
+    "@img/sharp-wasm32/@emnapi/runtime": ["@emnapi/runtime@1.7.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-PVtJr5CmLwYAU9PZDMITZoR5iAOShYREoR45EyyLrbntV50mdePTgUn4AmOw90Ifcj+x2kRjdzr1HP3RrNiHGA=="],
 
     "miniflare/zod": ["zod@3.22.3", "", {}, "sha512-EjIevzuJRiRPbVH4mGc8nApb/lVLKVpmUhAaR5R5doKGfAnGJ6Gr3CViAVjP+4FWSxCsybeWQdcgCtbX+7oZug=="],
   }

--- a/package.json
+++ b/package.json
@@ -10,11 +10,15 @@
 		"gql:generate": "gql.tada generate output",
 		"check": "biome check",
 		"format": "biome format --write",
-		"lint": "biome lint"
+		"lint": "biome lint",
+		"test": "vitest run",
+		"test:watch": "vitest",
+		"typecheck": "tsc --noEmit"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^2.3.8",
 		"typescript": "^5.9.3",
+		"vitest": "^4.1.7",
 		"wrangler": "^4.51.0"
 	},
 	"dependencies": {

--- a/src/cloudflare/client.test.ts
+++ b/src/cloudflare/client.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import { ErrorCode } from "../lib/errors";
+import { CloudflareMetricsClient } from "./client";
+
+function createClient(fetch: typeof globalThis.fetch): CloudflareMetricsClient {
+	return new CloudflareMetricsClient({
+		apiToken: "test-token",
+		queryLimit: 100,
+		scrapeDelaySeconds: 300,
+		timeWindowSeconds: 60,
+		fetch,
+	});
+}
+
+describe("CloudflareMetricsClient", () => {
+	it.each([
+		"worker-totals",
+		"logpush-account",
+		"magic-transit",
+		"magic-transit-slo",
+		"magic-transit-traffic",
+		"magic-firewall-samples",
+		"network-analytics",
+		"stream-video-playback",
+		"stream-live-inputs",
+	] as const)("surfaces %s access denial instead of reporting an empty refresh", async (query) => {
+		const fetch: typeof globalThis.fetch = async () =>
+			new Response(
+				JSON.stringify({
+					errors: [
+						{
+							message: "account does not have access to the path",
+							extensions: { code: "FORBIDDEN" },
+						},
+					],
+				}),
+				{ headers: { "content-type": "application/json" } },
+			);
+		const client = createClient(fetch);
+
+		await expect(
+			client.getAccountMetrics(query, "account-id", "Account", {
+				mintime: "2026-01-01T00:00:00.000Z",
+				maxtime: "2026-01-01T00:01:00.000Z",
+			}),
+		).rejects.toMatchObject({ code: ErrorCode.GRAPHQL_FIELD_ACCESS });
+	});
+
+	it("allows a successful query with no observations", async () => {
+		const fetch: typeof globalThis.fetch = async () =>
+			new Response(JSON.stringify({ data: { viewer: { accounts: [] } } }), {
+				headers: { "content-type": "application/json" },
+			});
+		const client = createClient(fetch);
+
+		await expect(
+			client.getAccountMetrics("network-analytics", "account-id", "Account", {
+				mintime: "2026-01-01T00:00:00.000Z",
+				maxtime: "2026-01-01T00:01:00.000Z",
+			}),
+		).resolves.toEqual([]);
+	});
+
+	it("surfaces zone analytics access denial for exporter backoff", async () => {
+		const fetch: typeof globalThis.fetch = async () =>
+			new Response(
+				JSON.stringify({
+					errors: [
+						{
+							message: "zone does not have access to the path",
+							extensions: { code: "FORBIDDEN" },
+						},
+					],
+				}),
+				{ headers: { "content-type": "application/json" } },
+			);
+		const client = createClient(fetch);
+
+		await expect(
+			client.getZoneMetrics(
+				"http-metrics",
+				["zone-id"],
+				[
+					{
+						id: "zone-id",
+						name: "example.com",
+						status: "active",
+						plan: { id: "paid", name: "Paid" },
+						account: { id: "account-id", name: "Account" },
+					},
+				],
+				{},
+				{
+					mintime: "2026-01-01T00:00:00.000Z",
+					maxtime: "2026-01-01T00:01:00.000Z",
+				},
+			),
+		).rejects.toMatchObject({ code: ErrorCode.GRAPHQL_FIELD_ACCESS });
+	});
+});

--- a/src/cloudflare/client.test.ts
+++ b/src/cloudflare/client.test.ts
@@ -61,7 +61,20 @@ describe("CloudflareMetricsClient", () => {
 		).resolves.toEqual([]);
 	});
 
-	it("surfaces zone analytics access denial for exporter backoff", async () => {
+	it.each([
+		"http-metrics",
+		"adaptive-metrics",
+		"edge-country-metrics",
+		"colo-metrics",
+		"colo-error-metrics",
+		"request-method-metrics",
+		"health-check-metrics",
+		"load-balancer-metrics",
+		"logpush-zone",
+		"origin-status-metrics",
+		"cache-miss-metrics",
+		"hostname-http-metrics",
+	] as const)("surfaces %s access denial for exporter backoff", async (query) => {
 		const fetch: typeof globalThis.fetch = async () =>
 			new Response(
 				JSON.stringify({
@@ -78,7 +91,7 @@ describe("CloudflareMetricsClient", () => {
 
 		await expect(
 			client.getZoneMetrics(
-				"http-metrics",
+				query,
 				["zone-id"],
 				[
 					{
@@ -94,6 +107,9 @@ describe("CloudflareMetricsClient", () => {
 					mintime: "2026-01-01T00:00:00.000Z",
 					maxtime: "2026-01-01T00:01:00.000Z",
 				},
+				query === "hostname-http-metrics"
+					? new Set(["example.com"])
+					: undefined,
 			),
 		).rejects.toMatchObject({ code: ErrorCode.GRAPHQL_FIELD_ACCESS });
 	});

--- a/src/cloudflare/client.ts
+++ b/src/cloudflare/client.ts
@@ -1,4 +1,4 @@
-import { Client, fetchExchange } from "@urql/core";
+import { Client, type CombinedError, fetchExchange } from "@urql/core";
 import Cloudflare from "cloudflare";
 import DataLoader from "dataloader";
 import z from "zod";
@@ -65,6 +65,14 @@ export {
 } from "./queries";
 
 const API_PAGE_SIZE = 100;
+
+function graphQLQueryError(query: string, error: CombinedError): GraphQLError {
+	return new GraphQLError(
+		`GraphQL error (${query}): ${error.message}`,
+		error.graphQLErrors ?? [],
+		{ context: { query } },
+	);
+}
 
 /**
  * Groups HTTP status code into category string.
@@ -564,8 +572,7 @@ export class CloudflareMetricsClient {
 		});
 
 		if (result.error) {
-			this.logger.error("GraphQL error", { error: result.error.message });
-			return [];
+			throw graphQLQueryError("worker-totals", result.error);
 		}
 
 		const metrics: MetricDefinition[] = [];
@@ -674,8 +681,7 @@ export class CloudflareMetricsClient {
 		});
 
 		if (result.error) {
-			this.logger.error("GraphQL error", { error: result.error.message });
-			return [];
+			throw graphQLQueryError("logpush-account", result.error);
 		}
 
 		const metric: MetricDefinition = {
@@ -723,8 +729,7 @@ export class CloudflareMetricsClient {
 		});
 
 		if (result.error) {
-			this.logger.error("GraphQL error", { error: result.error.message });
-			return [];
+			throw graphQLQueryError("magic-transit", result.error);
 		}
 
 		const activeTunnels: MetricDefinition = {
@@ -916,10 +921,7 @@ export class CloudflareMetricsClient {
 		});
 
 		if (result.error) {
-			this.logger.error("GraphQL error (magic-transit-slo)", {
-				error: result.error.message,
-			});
-			return [];
+			throw graphQLQueryError("magic-transit-slo", result.error);
 		}
 
 		const sloStatus: MetricDefinition = {
@@ -1049,10 +1051,7 @@ export class CloudflareMetricsClient {
 		});
 
 		if (result.error) {
-			this.logger.error("GraphQL error (magic-transit-traffic)", {
-				error: result.error.message,
-			});
-			return [];
+			throw graphQLQueryError("magic-transit-traffic", result.error);
 		}
 
 		const bits: MetricDefinition = {
@@ -1114,10 +1113,7 @@ export class CloudflareMetricsClient {
 		});
 
 		if (result.error) {
-			this.logger.error("GraphQL error (magic-firewall-samples)", {
-				error: result.error.message,
-			});
-			return [];
+			throw graphQLQueryError("magic-firewall-samples", result.error);
 		}
 
 		const bits: MetricDefinition = {
@@ -1178,10 +1174,7 @@ export class CloudflareMetricsClient {
 		});
 
 		if (result.error) {
-			this.logger.error("GraphQL error (network-analytics)", {
-				error: result.error.message,
-			});
-			return [];
+			throw graphQLQueryError("network-analytics", result.error);
 		}
 
 		const metrics: MetricDefinition[] = [];
@@ -1335,11 +1328,7 @@ export class CloudflareMetricsClient {
 			limit: this.config.queryLimit,
 		});
 		if (result.error) {
-			this.logger.error("GraphQL error (stream-video-playback)", {
-				account: normalizedAccount,
-				error: result.error.message,
-			});
-			return [];
+			throw graphQLQueryError("stream-video-playback", result.error);
 		}
 
 		const playbackCount: MetricDefinition = {
@@ -1397,11 +1386,7 @@ export class CloudflareMetricsClient {
 		});
 
 		if (result.error) {
-			this.logger.error("GraphQL error (stream-live-inputs)", {
-				account: normalizedAccount,
-				error: result.error.message,
-			});
-			return [];
+			throw graphQLQueryError("stream-live-inputs", result.error);
 		}
 
 		const segments: MetricDefinition = {
@@ -1612,13 +1597,10 @@ export class CloudflareMetricsClient {
 			result = await this.gql.query(HTTPMetricsQueryNoBots, queryVars);
 		}
 
-		// Safety net: free tier zones should be filtered upstream, but handle gracefully
+		// Safety net: free tier zones should be filtered upstream. Surface access
+		// failures so the exporter can back off rather than retry every minute.
 		if (result.error?.message.includes("does not have access to the path")) {
-			this.logger.error(
-				"Zone(s) lack GraphQL analytics access - ensure free tier zones are filtered",
-				{ error: result.error.message },
-			);
-			return [];
+			throw graphQLQueryError("http-metrics", result.error);
 		}
 
 		if (result.error) {

--- a/src/cloudflare/client.ts
+++ b/src/cloudflare/client.ts
@@ -2027,7 +2027,7 @@ export class CloudflareMetricsClient {
 		});
 
 		if (result.error) {
-			throw new Error(`GraphQL error: ${result.error.message}`);
+			throw graphQLQueryError("adaptive-metrics", result.error);
 		}
 
 		const error4xx: MetricDefinition = {
@@ -2133,7 +2133,7 @@ export class CloudflareMetricsClient {
 		});
 
 		if (result.error) {
-			throw new Error(`GraphQL error: ${result.error.message}`);
+			throw graphQLQueryError("edge-country-metrics", result.error);
 		}
 
 		const statusCountryHost: MetricDefinition = {
@@ -2221,7 +2221,7 @@ export class CloudflareMetricsClient {
 		});
 
 		if (result.error) {
-			throw new Error(`GraphQL error: ${result.error.message}`);
+			throw graphQLQueryError("colo-metrics", result.error);
 		}
 
 		const visits: MetricDefinition = {
@@ -2297,7 +2297,7 @@ export class CloudflareMetricsClient {
 		});
 
 		if (result.error) {
-			throw new Error(`GraphQL error: ${result.error.message}`);
+			throw graphQLQueryError("colo-error-metrics", result.error);
 		}
 
 		const visitsError: MetricDefinition = {
@@ -2374,7 +2374,7 @@ export class CloudflareMetricsClient {
 		});
 
 		if (result.error) {
-			throw new Error(`GraphQL error: ${result.error.message}`);
+			throw graphQLQueryError("request-method-metrics", result.error);
 		}
 
 		const methodCount: MetricDefinition = {
@@ -2994,7 +2994,7 @@ export class CloudflareMetricsClient {
 		});
 
 		if (result.error) {
-			throw new Error(`GraphQL error: ${result.error.message}`);
+			throw graphQLQueryError("logpush-zone", result.error);
 		}
 
 		const failedJobs: MetricDefinition = {
@@ -3047,7 +3047,7 @@ export class CloudflareMetricsClient {
 		});
 
 		if (result.error) {
-			throw new Error(`GraphQL error: ${result.error.message}`);
+			throw graphQLQueryError("origin-status-metrics", result.error);
 		}
 
 		const originStatusCountryHost: MetricDefinition = {

--- a/src/durable-objects/MetricExporter.test.ts
+++ b/src/durable-objects/MetricExporter.test.ts
@@ -1,0 +1,219 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { MetricExporter } from "./MetricExporter";
+
+class AlarmStorage {
+	readonly setAlarm = vi.fn().mockResolvedValue(undefined);
+	getManyFailures = 0;
+	readonly values = new Map<string, unknown>();
+
+	async get(keyOrKeys: string | string[]): Promise<unknown> {
+		if (this.getManyFailures > 0) {
+			this.getManyFailures--;
+			throw new Error("state storage unavailable");
+		}
+		if (typeof keyOrKeys === "string") return this.values.get(keyOrKeys);
+		const result = new Map<string, unknown>();
+		for (const key of keyOrKeys) {
+			if (this.values.has(key)) result.set(key, this.values.get(key));
+		}
+		return result;
+	}
+
+	async put(entries: Record<string, unknown>): Promise<void> {
+		for (const [key, value] of Object.entries(entries)) {
+			this.values.set(key, value);
+		}
+	}
+
+	async delete(keys: string[]): Promise<void> {
+		for (const key of keys) this.values.delete(key);
+	}
+}
+
+function createExporter(
+	storage: AlarmStorage,
+	envOverrides: Record<string, unknown> = {},
+): {
+	exporter: MetricExporter;
+	ready: Promise<void>;
+} {
+	let ready = Promise.resolve();
+	const ctx = {
+		storage,
+		blockConcurrencyWhile(callback: () => Promise<void>) {
+			ready = callback();
+		},
+	};
+	const env = {
+		LOG_FORMAT: "json",
+		LOG_LEVEL: "error",
+		...envOverrides,
+	};
+	return {
+		exporter: new MetricExporter(
+			ctx as unknown as DurableObjectState,
+			env as unknown as Env,
+		),
+		ready,
+	};
+}
+
+function storedState(): Record<string, unknown> {
+	return {
+		scopeType: "account",
+		scopeId: "account-id",
+		queryName: "worker-totals",
+		counters: {},
+		metrics: [],
+		lastIngest: 0,
+		accountId: "account-id",
+		accountName: "Account",
+		zones: [],
+		firewallRules: {},
+		zoneMetadata: null,
+		refreshInterval: 60,
+		lastRefresh: 0,
+		lastError: null,
+		lastSslFetch: 0,
+	};
+}
+
+afterEach(() => {
+	vi.restoreAllMocks();
+	vi.unstubAllGlobals();
+});
+
+describe("MetricExporter state recovery", () => {
+	it("schedules recovery when constructor state loading keeps failing", async () => {
+		const storage = new AlarmStorage();
+		storage.getManyFailures = 2;
+		const { exporter, ready } = createExporter(storage);
+		await ready;
+
+		await expect(exporter.alarm()).resolves.toBeUndefined();
+
+		expect(storage.setAlarm).toHaveBeenCalledOnce();
+	});
+
+	it("backs off only a denied zone chunk while refreshing successful chunks", async () => {
+		const storage = new AlarmStorage();
+		const zones = Array.from({ length: 11 }, (_, index) => ({
+			id: `zone-${index}`,
+			name: `zone-${index}.example.com`,
+			status: "active",
+			plan: { id: "paid", name: "Paid" },
+			account: { id: "account-id", name: "Account" },
+		}));
+		storage.values.set("state", {
+			...storedState(),
+			queryName: "adaptive-metrics",
+			zones,
+		});
+		const fetch = vi
+			.fn<typeof globalThis.fetch>()
+			.mockResolvedValueOnce(
+				new Response(
+					JSON.stringify({
+						errors: [
+							{
+								message: "zone does not have access to the path",
+								extensions: { code: "FORBIDDEN" },
+							},
+						],
+					}),
+					{ headers: { "content-type": "application/json" } },
+				),
+			)
+			.mockResolvedValue(
+				new Response(JSON.stringify({ data: { viewer: { zones: [] } } }), {
+					headers: { "content-type": "application/json" },
+				}),
+			);
+		vi.stubGlobal("fetch", fetch);
+		const consoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+		const rateLimiter = { limit: vi.fn().mockResolvedValue({ success: true }) };
+		const { exporter, ready } = createExporter(storage, {
+			CLOUDFLARE_API_TOKEN: "token",
+			CONFIG_KV: { get: vi.fn().mockResolvedValue(null) },
+			CF_API_RATE_LIMITER: rateLimiter,
+		});
+		await ready;
+
+		await exporter.alarm();
+		await exporter.alarm();
+
+		expect(fetch).toHaveBeenCalledTimes(3);
+		expect(storage.setAlarm).toHaveBeenCalledTimes(2);
+		consoleLog.mockRestore();
+		vi.unstubAllGlobals();
+	});
+
+	it("does not double-count when the platform retries the same alarm window", async () => {
+		const storage = new AlarmStorage();
+		const zone = {
+			id: "zone-id",
+			name: "example.com",
+			status: "active",
+			plan: { id: "paid", name: "Paid" },
+			account: { id: "account-id", name: "Account" },
+		};
+		storage.values.set("state", { ...storedState(), zones: [zone] });
+		storage.setAlarm
+			.mockRejectedValueOnce(new Error("ordinary alarm scheduling failed"))
+			.mockRejectedValueOnce(new Error("recovery alarm scheduling failed"));
+		const fetch = vi.fn<typeof globalThis.fetch>().mockResolvedValue(
+			new Response(
+				JSON.stringify({
+					data: {
+						viewer: {
+							accounts: [
+								{
+									workersInvocationsAdaptive: [
+										{
+											dimensions: { scriptName: "worker" },
+											sum: { requests: 42, errors: 0 },
+											quantiles: null,
+										},
+									],
+								},
+							],
+						},
+					},
+				}),
+				{ headers: { "content-type": "application/json" } },
+			),
+		);
+		vi.stubGlobal("fetch", fetch);
+		vi.spyOn(console, "log").mockImplementation(() => {});
+		const rateLimiter = { limit: vi.fn().mockResolvedValue({ success: true }) };
+		const { exporter, ready } = createExporter(storage, {
+			CLOUDFLARE_API_TOKEN: "token",
+			CONFIG_KV: { get: vi.fn().mockResolvedValue(null) },
+			CF_API_RATE_LIMITER: rateLimiter,
+		});
+		await ready;
+
+		await expect(exporter.alarm()).rejects.toThrow(
+			"recovery alarm scheduling failed",
+		);
+		await exporter.alarm();
+
+		const metrics = await exporter.export();
+		const requests = metrics.find(
+			(metric) => metric.name === "cloudflare_worker_requests_total",
+		);
+		expect(requests?.values[0]?.value).toBe(42);
+	});
+
+	it("retries a transient constructor load before initialize can overwrite state", async () => {
+		const storage = new AlarmStorage();
+		storage.getManyFailures = 1;
+		storage.values.set("state", storedState());
+		const { exporter, ready } = createExporter(storage);
+		await ready;
+
+		await exporter.initialize("account:account-id:worker-totals");
+
+		await expect(exporter.export()).resolves.toEqual([]);
+	});
+});

--- a/src/durable-objects/MetricExporter.ts
+++ b/src/durable-objects/MetricExporter.ts
@@ -65,6 +65,7 @@ const MetricExporterStateSchema = z.object({
 	refreshInterval: z.number(),
 	lastRefresh: z.number(),
 	lastError: z.string().nullable(),
+	zoneRetryAfter: z.record(z.string(), z.number()).default({}),
 
 	// SSL cert cache (zone-scoped only)
 	lastSslFetch: z.number(),
@@ -72,22 +73,47 @@ const MetricExporterStateSchema = z.object({
 
 type MetricExporterState = z.infer<typeof MetricExporterStateSchema>;
 
+type MetricFetchResult = {
+	metrics: MetricDefinition[];
+	partialErrors: unknown[];
+	failedScopes: ReadonlySet<string>;
+	zoneRetryAfter: Record<string, number>;
+};
+
 /**
  * Durable Object that fetches and exports Prometheus metrics for a specific query scope.
  * Handles counter accumulation, alarm-based refresh scheduling, and metric caching.
  */
 export class MetricExporter extends DurableObject<Env> {
 	private state: MetricExporterState | undefined;
+	private stateLoadFailed = false;
 
 	constructor(ctx: DurableObjectState, env: Env) {
 		super(ctx, env);
 		ctx.blockConcurrencyWhile(async () => {
-			this.state = await loadChunkedValue(
-				chunkedDurableObjectStorage(ctx.storage),
-				STATE_KEY,
-				MetricExporterStateSchema,
-			);
+			try {
+				await this.loadState();
+			} catch {
+				// Keep the object alive so alarm() can schedule indefinite recovery.
+				this.stateLoadFailed = true;
+			}
 		});
+	}
+
+	/** Load and validate state from Durable Object storage. */
+	private async loadState(): Promise<void> {
+		this.state = await loadChunkedValue(
+			chunkedDurableObjectStorage(this.ctx.storage),
+			STATE_KEY,
+			MetricExporterStateSchema,
+		);
+		this.stateLoadFailed = false;
+	}
+
+	/** Retry constructor load failures from inside the protected alarm path. */
+	private async retryFailedStateLoad(): Promise<void> {
+		if (!this.stateLoadFailed) return;
+		await this.loadState();
 	}
 
 	/**
@@ -147,11 +173,15 @@ export class MetricExporter extends DurableObject<Env> {
 		if (this.state !== undefined) {
 			return;
 		}
+		if (this.stateLoadFailed) {
+			await this.loadState();
+			if (this.state !== undefined) return;
+		}
 
 		const config = await getConfig(this.env);
 		const parsed = MetricExporterIdSchema.parse(id);
 
-		this.state = {
+		const initializedState: MetricExporterState = {
 			scopeType: parsed.scopeType,
 			scopeId: parsed.scopeId,
 			queryName: parsed.queryName,
@@ -166,10 +196,12 @@ export class MetricExporter extends DurableObject<Env> {
 			refreshInterval: config.metricRefreshIntervalSeconds,
 			lastRefresh: 0,
 			lastError: null,
+			zoneRetryAfter: {},
 			lastSslFetch: 0,
 		};
 
-		await this.saveState();
+		await this.saveState(initializedState);
+		this.state = initializedState;
 	}
 
 	/**
@@ -202,14 +234,15 @@ export class MetricExporter extends DurableObject<Env> {
 		const isFirstContext =
 			state.zones.length === 0 && zones.length > 0 && state.lastRefresh === 0;
 
-		this.state = {
+		const updatedState: MetricExporterState = {
 			...state,
 			accountId,
 			accountName,
 			zones,
 			firewallRules,
 		};
-		await this.saveState();
+		await this.saveState(updatedState);
+		this.state = updatedState;
 
 		logger.info("Zone context updated", { zone_count: zones.length });
 
@@ -246,13 +279,14 @@ export class MetricExporter extends DurableObject<Env> {
 
 		const isFirstInit = state.zoneMetadata === null && state.lastRefresh === 0;
 
-		this.state = {
+		const updatedState: MetricExporterState = {
 			...state,
 			accountId,
 			accountName,
 			zoneMetadata: zone,
 		};
-		await this.saveState();
+		await this.saveState(updatedState);
+		this.state = updatedState;
 
 		logger.info("Zone metadata set", { zone: zone.name });
 
@@ -272,6 +306,7 @@ export class MetricExporter extends DurableObject<Env> {
 		await runAlarmWithRecovery({
 			run: async () => {
 				logger = createLogger("metric_exporter_alarm", configFromEnv(this.env));
+				await this.retryFailedStateLoad();
 				const config = await getConfig(this.env);
 				logger = this.createLogger(config);
 				logger.info("Alarm fired, refreshing");
@@ -346,10 +381,10 @@ export class MetricExporter extends DurableObject<Env> {
 		let nextRefreshDelaySeconds = config.metricRefreshIntervalSeconds;
 
 		try {
-			let metrics: MetricDefinition[];
+			let result: MetricFetchResult;
 
 			if (state.scopeType === "account") {
-				metrics = await this.fetchAccountScopedMetrics(
+				result = await this.fetchAccountScopedMetrics(
 					client,
 					state,
 					timeRange,
@@ -357,24 +392,42 @@ export class MetricExporter extends DurableObject<Env> {
 					logger,
 				);
 			} else {
-				metrics = await this.fetchZoneScopedMetrics(client, state);
+				result = {
+					metrics: await this.fetchZoneScopedMetrics(client, state),
+					partialErrors: [],
+					failedScopes: new Set(),
+					zoneRetryAfter: {},
+				};
 			}
 
-			const processed = accumulateCounterMetrics(metrics, state.counters);
-
-			this.state = {
-				...state,
+			const ingestId = new Date(timeRange.maxtime).getTime();
+			const processed = accumulateCounterMetrics(
+				result.metrics,
+				state.counters,
+				{
+					ingestId,
+					ageMissingCounters: state.lastIngest !== ingestId,
+					failedScopes: result.failedScopes,
+				},
+			);
+			const currentState = this.getState();
+			const refreshedState: MetricExporterState = {
+				...currentState,
 				metrics: processed.metrics,
 				counters: processed.counters,
+				lastIngest: ingestId,
 				lastRefresh: Date.now(),
 				lastSslFetch:
-					state.scopeType === "zone" ? Date.now() : state.lastSslFetch,
+					state.scopeType === "zone" ? Date.now() : currentState.lastSslFetch,
 				lastError: null,
+				zoneRetryAfter: result.zoneRetryAfter,
 			};
-			await this.saveState();
+			await this.saveState(refreshedState);
+			this.state = refreshedState;
 
 			logger.info("Refresh complete", {
-				metric_count: metrics.length,
+				metric_count: result.metrics.length,
+				partial_failure_count: result.partialErrors.length,
 			});
 		} catch (error) {
 			const msg = error instanceof Error ? error.message : String(error);
@@ -386,8 +439,12 @@ export class MetricExporter extends DurableObject<Env> {
 				error: msg,
 				retry_seconds: nextRefreshDelaySeconds,
 			});
-			this.state = { ...state, lastError: msg };
-			await this.saveState();
+			const errorState: MetricExporterState = {
+				...this.getState(),
+				lastError: msg,
+			};
+			await this.saveState(errorState);
+			this.state = errorState;
 		}
 
 		await this.scheduleNextAlarm(config, nextRefreshDelaySeconds);
@@ -431,17 +488,22 @@ export class MetricExporter extends DurableObject<Env> {
 		timeRange: TimeRange,
 		config: ResolvedConfig,
 		logger: Logger,
-	): Promise<MetricDefinition[]> {
+	): Promise<MetricFetchResult> {
 		const { queryName, accountId, accountName, zones, firewallRules } = state;
 
 		// Account-level queries (worker-totals, logpush-account, magic-transit)
 		if (isAccountLevelQuery(queryName)) {
-			return client.getAccountMetrics(
-				queryName,
-				accountId,
-				accountName,
-				timeRange,
-			);
+			return {
+				metrics: await client.getAccountMetrics(
+					queryName,
+					accountId,
+					accountName,
+					timeRange,
+				),
+				partialErrors: [],
+				failedScopes: new Set(),
+				zoneRetryAfter: {},
+			};
 		}
 
 		// Zone-batched queries - fetch all zones in one GraphQL call
@@ -455,14 +517,24 @@ export class MetricExporter extends DurableObject<Env> {
 				const normalized = new Set([...parsed].map((h) => h.toLowerCase()));
 				if (normalized.size === 0) {
 					logger.debug("Hostname metrics disabled: empty allowlist");
-					return [];
+					return {
+						metrics: [],
+						partialErrors: [],
+						failedScopes: new Set(),
+						zoneRetryAfter: {},
+					};
 				}
 				if (normalized.size > MAX_HOSTNAME_ALLOWLIST_SIZE) {
 					logger.error("Hostname allowlist exceeds maximum size", {
 						size: normalized.size,
 						max: MAX_HOSTNAME_ALLOWLIST_SIZE,
 					});
-					return [];
+					return {
+						metrics: [],
+						partialErrors: [],
+						failedScopes: new Set(),
+						zoneRetryAfter: {},
+					};
 				}
 				// excludeHost strips host labels from all metrics in prometheus.ts,
 				// which would collapse distinct hostnames into duplicate gauge series
@@ -471,7 +543,12 @@ export class MetricExporter extends DurableObject<Env> {
 					logger.warn(
 						"Hostname metrics disabled: excludeHost=true strips host labels",
 					);
-					return [];
+					return {
+						metrics: [],
+						partialErrors: [],
+						failedScopes: new Set(),
+						zoneRetryAfter: {},
+					};
 				}
 				hostMetricsAllowlist = normalized;
 				hostMetricsDelaySeconds = config.hostMetricsDelaySeconds;
@@ -493,7 +570,12 @@ export class MetricExporter extends DurableObject<Env> {
 
 				if (zonesToQuery.length === 0) {
 					logger.info("No paid tier zones to query");
-					return [];
+					return {
+						metrics: [],
+						partialErrors: [],
+						failedScopes: new Set(),
+						zoneRetryAfter: {},
+					};
 				}
 			}
 
@@ -503,21 +585,49 @@ export class MetricExporter extends DurableObject<Env> {
 
 			if (zonesToQuery.length <= ZONES_PER_CHUNK) {
 				const zoneIds = zonesToQuery.map((z) => z.id);
-				return client.getZoneMetrics(
-					queryName,
-					zoneIds,
-					zonesToQuery,
-					firewallRules,
-					timeRange,
-					hostMetricsAllowlist,
-					hostMetricsDelaySeconds,
-				);
+				return {
+					metrics: await client.getZoneMetrics(
+						queryName,
+						zoneIds,
+						zonesToQuery,
+						firewallRules,
+						timeRange,
+						hostMetricsAllowlist,
+						hostMetricsDelaySeconds,
+					),
+					partialErrors: [],
+					failedScopes: new Set(),
+					zoneRetryAfter: {},
+				};
 			}
 
 			const chunkResults: MetricDefinition[][] = [];
+			const partialErrors: unknown[] = [];
+			const failedScopes = new Set<string>();
+			const currentZoneIds = new Set(zonesToQuery.map((zone) => zone.id));
+			const now = Date.now();
+			const zoneRetryAfter: Record<string, number> = {};
+			for (const [zoneId, retryAfter] of Object.entries(state.zoneRetryAfter)) {
+				if (currentZoneIds.has(zoneId) && retryAfter > now) {
+					zoneRetryAfter[zoneId] = retryAfter;
+				}
+			}
+			const queryableZones = zonesToQuery.filter((zone) => {
+				const retryAfter = zoneRetryAfter[zone.id] ?? 0;
+				if (retryAfter <= now) return true;
+				failedScopes.add(zone.name);
+				logger.debug("Skipping zone during product-access backoff", {
+					query: queryName,
+					zone: zone.name,
+					retry_after: new Date(retryAfter).toISOString(),
+				});
+				return false;
+			});
 			let firstChunkError: unknown;
-			for (let i = 0; i < zonesToQuery.length; i += ZONES_PER_CHUNK) {
-				const chunkZones = zonesToQuery.slice(i, i + ZONES_PER_CHUNK);
+			let longestRetryError: unknown;
+			let longestRetrySeconds = config.metricRefreshIntervalSeconds;
+			for (let i = 0; i < queryableZones.length; i += ZONES_PER_CHUNK) {
+				const chunkZones = queryableZones.slice(i, i + ZONES_PER_CHUNK);
 				const chunkIds = chunkZones.map((z) => z.id);
 
 				try {
@@ -530,12 +640,26 @@ export class MetricExporter extends DurableObject<Env> {
 						hostMetricsAllowlist,
 						hostMetricsDelaySeconds,
 					);
+					for (const zoneId of chunkIds) delete zoneRetryAfter[zoneId];
 					chunkResults.push(metrics);
 				} catch (error) {
 					firstChunkError ??= error;
+					partialErrors.push(error);
+					for (const zone of chunkZones) failedScopes.add(zone.name);
+					const retrySeconds = getMetricRefreshDelaySeconds(
+						error,
+						config.metricRefreshIntervalSeconds,
+					);
+					if (retrySeconds > longestRetrySeconds) {
+						longestRetrySeconds = retrySeconds;
+						longestRetryError = error;
+					}
+					if (retrySeconds > config.metricRefreshIntervalSeconds) {
+						for (const zoneId of chunkIds) {
+							zoneRetryAfter[zoneId] = now + retrySeconds * 1000;
+						}
+					}
 					// Log and continue — partial results from other chunks are still valuable.
-					// Missing zones don't increment their counters this cycle;
-					// accumulateCounterMetrics() retains their state for the expiry window.
 					logger.error("Zone chunk query failed", {
 						query: queryName,
 						chunk_index: Math.floor(i / ZONES_PER_CHUNK),
@@ -543,19 +667,30 @@ export class MetricExporter extends DurableObject<Env> {
 						total_zones: zonesToQuery.length,
 						failed_zones: chunkZones.map((z) => z.name),
 						error: error instanceof Error ? error.message : String(error),
+						retry_seconds: retrySeconds,
 					});
 				}
 			}
 
 			if (chunkResults.length === 0 && firstChunkError !== undefined) {
-				throw firstChunkError;
+				throw longestRetryError ?? firstChunkError;
 			}
-			return mergeMetricDefinitions(...chunkResults);
+			return {
+				metrics: mergeMetricDefinitions(...chunkResults),
+				partialErrors,
+				failedScopes,
+				zoneRetryAfter,
+			};
 		}
 
 		// Unknown query - should not happen if IDs are constructed correctly
 		console.error("Unknown query type", { queryName });
-		return [];
+		return {
+			metrics: [],
+			partialErrors: [],
+			failedScopes: new Set(),
+			zoneRetryAfter: {},
+		};
 	}
 
 	/**
@@ -587,12 +722,12 @@ export class MetricExporter extends DurableObject<Env> {
 		}
 	}
 
-	/** Persist current state in bounded storage chunks. */
-	private async saveState(): Promise<void> {
+	/** Persist state in bounded storage chunks before publishing it in memory. */
+	private async saveState(state: MetricExporterState): Promise<void> {
 		await saveChunkedValue(
 			chunkedDurableObjectStorage(this.ctx.storage),
 			STATE_KEY,
-			this.getState(),
+			state,
 		);
 	}
 

--- a/src/durable-objects/MetricExporter.ts
+++ b/src/durable-objects/MetricExporter.ts
@@ -1,25 +1,34 @@
 import { DurableObject } from "cloudflare:workers";
+import z from "zod";
 import {
 	getCloudflareMetricsClient,
 	isAccountLevelQuery,
 	isZoneLevelQuery,
 } from "../cloudflare/client";
 import { isPaidTierGraphQLQuery } from "../cloudflare/queries";
+import {
+	chunkedDurableObjectStorage,
+	loadChunkedValue,
+	saveChunkedValue,
+} from "../lib/chunked-storage";
+import { accumulateCounterMetrics } from "../lib/counters";
 import { parseCommaSeparated, partitionZonesByTier } from "../lib/filters";
 import { createLogger, type Logger } from "../lib/logger";
+import { getMetricRefreshDelaySeconds } from "../lib/metric-refresh";
 import {
 	type MetricDefinition,
-	type MetricValue,
+	MetricDefinitionSchema,
 	mergeMetricDefinitions,
 } from "../lib/metrics";
 import { getConfig, type ResolvedConfig } from "../lib/runtime-config";
-import { getTimeRange, metricKey } from "../lib/time";
+import { getTimeRange } from "../lib/time";
 import {
-	type CounterState,
+	CounterStateSchema,
 	MetricExporterIdSchema,
 	type MetricExporterIdString,
 	type TimeRange,
 	type Zone,
+	ZoneSchema,
 } from "../lib/types";
 
 const STATE_KEY = "state";
@@ -30,34 +39,36 @@ const STATE_KEY = "state";
  */
 const MAX_HOSTNAME_ALLOWLIST_SIZE = 50;
 
-type MetricExporterState = {
+const MetricExporterStateSchema = z.object({
 	// Core identity
-	scopeType: "account" | "zone";
-	scopeId: string;
-	queryName: string;
+	scopeType: z.enum(["account", "zone"]),
+	scopeId: z.string(),
+	queryName: z.string(),
 
 	// Metric storage
-	counters: Record<string, CounterState>;
-	metrics: MetricDefinition[];
-	lastIngest: number;
+	counters: z.record(z.string(), CounterStateSchema),
+	metrics: z.array(MetricDefinitionSchema),
+	lastIngest: z.number(),
 
 	// Context for fetching (account-scoped)
-	accountId: string;
-	accountName: string;
-	zones: Zone[];
-	firewallRules: Record<string, string>;
+	accountId: z.string(),
+	accountName: z.string(),
+	zones: z.array(ZoneSchema),
+	firewallRules: z.record(z.string(), z.string()),
 
 	// Context for fetching (zone-scoped)
-	zoneMetadata: Zone | null;
+	zoneMetadata: ZoneSchema.nullable(),
 
 	// Refresh state
-	refreshInterval: number;
-	lastRefresh: number;
-	lastError: string | null;
+	refreshInterval: z.number(),
+	lastRefresh: z.number(),
+	lastError: z.string().nullable(),
 
 	// SSL cert cache (zone-scoped only)
-	lastSslFetch: number;
-};
+	lastSslFetch: z.number(),
+});
+
+type MetricExporterState = z.infer<typeof MetricExporterStateSchema>;
 
 /**
  * Durable Object that fetches and exports Prometheus metrics for a specific query scope.
@@ -69,7 +80,11 @@ export class MetricExporter extends DurableObject<Env> {
 	constructor(ctx: DurableObjectState, env: Env) {
 		super(ctx, env);
 		ctx.blockConcurrencyWhile(async () => {
-			this.state = await ctx.storage.get<MetricExporterState>(STATE_KEY);
+			this.state = await loadChunkedValue(
+				chunkedDurableObjectStorage(ctx.storage),
+				STATE_KEY,
+				MetricExporterStateSchema,
+			);
 		});
 	}
 
@@ -152,7 +167,7 @@ export class MetricExporter extends DurableObject<Env> {
 			lastSslFetch: 0,
 		};
 
-		await this.ctx.storage.put(STATE_KEY, this.state);
+		await this.saveState();
 	}
 
 	/**
@@ -192,7 +207,7 @@ export class MetricExporter extends DurableObject<Env> {
 			zones,
 			firewallRules,
 		};
-		await this.ctx.storage.put(STATE_KEY, this.state);
+		await this.saveState();
 
 		logger.info("Zone context updated", { zone_count: zones.length });
 
@@ -235,7 +250,7 @@ export class MetricExporter extends DurableObject<Env> {
 			accountName,
 			zoneMetadata: zone,
 		};
-		await this.ctx.storage.put(STATE_KEY, this.state);
+		await this.saveState();
 
 		logger.info("Zone metadata set", { zone: zone.name });
 
@@ -316,6 +331,7 @@ export class MetricExporter extends DurableObject<Env> {
 		}
 
 		const client = getCloudflareMetricsClient(this.env);
+		let nextRefreshDelaySeconds = config.metricRefreshIntervalSeconds;
 
 		try {
 			let metrics: MetricDefinition[];
@@ -332,7 +348,7 @@ export class MetricExporter extends DurableObject<Env> {
 				metrics = await this.fetchZoneScopedMetrics(client, state);
 			}
 
-			const processed = this.processCounters(metrics, state.counters);
+			const processed = accumulateCounterMetrics(metrics, state.counters);
 
 			this.state = {
 				...state,
@@ -343,19 +359,26 @@ export class MetricExporter extends DurableObject<Env> {
 					state.scopeType === "zone" ? Date.now() : state.lastSslFetch,
 				lastError: null,
 			};
-			await this.ctx.storage.put(STATE_KEY, this.state);
+			await this.saveState();
 
 			logger.info("Refresh complete", {
 				metric_count: metrics.length,
 			});
 		} catch (error) {
 			const msg = error instanceof Error ? error.message : String(error);
-			logger.error("Refresh failed", { error: msg });
+			nextRefreshDelaySeconds = getMetricRefreshDelaySeconds(
+				error,
+				config.metricRefreshIntervalSeconds,
+			);
+			logger.error("Refresh failed", {
+				error: msg,
+				retry_seconds: nextRefreshDelaySeconds,
+			});
 			this.state = { ...state, lastError: msg };
-			await this.ctx.storage.put(STATE_KEY, this.state);
+			await this.saveState();
 		}
 
-		await this.scheduleNextAlarm(config);
+		await this.scheduleNextAlarm(config, nextRefreshDelaySeconds);
 	}
 
 	/**
@@ -363,17 +386,18 @@ export class MetricExporter extends DurableObject<Env> {
 	 *
 	 * @param config Resolved runtime configuration.
 	 */
-	private async scheduleNextAlarm(config: ResolvedConfig): Promise<void> {
+	private async scheduleNextAlarm(
+		config: ResolvedConfig,
+		delaySeconds: number = config.metricRefreshIntervalSeconds,
+	): Promise<void> {
 		const intervalMs = config.metricRefreshIntervalSeconds * 1000;
-
-		// Get the start of the current minute interval
+		const delayMs = delaySeconds * 1000;
 		const now = Date.now();
-		const startOfInterval = Math.floor(now / intervalMs) * intervalMs;
-
-		// Add the jitter (1-5s) to the NEXT interval start
-		// This ensures we always fire at ":01-05" of every interval
 		const jitter = 1000 + Math.random() * 4000;
-		const nextAlarm = startOfInterval + intervalMs + jitter;
+		const nextAlarm =
+			delaySeconds === config.metricRefreshIntervalSeconds
+				? Math.floor(now / intervalMs) * intervalMs + intervalMs + jitter
+				: now + delayMs + jitter;
 
 		await this.ctx.storage.setAlarm(nextAlarm);
 	}
@@ -479,6 +503,7 @@ export class MetricExporter extends DurableObject<Env> {
 			}
 
 			const chunkResults: MetricDefinition[][] = [];
+			let firstChunkError: unknown;
 			for (let i = 0; i < zonesToQuery.length; i += ZONES_PER_CHUNK) {
 				const chunkZones = zonesToQuery.slice(i, i + ZONES_PER_CHUNK);
 				const chunkIds = chunkZones.map((z) => z.id);
@@ -495,10 +520,10 @@ export class MetricExporter extends DurableObject<Env> {
 					);
 					chunkResults.push(metrics);
 				} catch (error) {
+					firstChunkError ??= error;
 					// Log and continue — partial results from other chunks are still valuable.
 					// Missing zones don't increment their counters this cycle;
-					// processCounters() accumulates per (name, labels) key so existing
-					// counter values are preserved. Next alarm retries all chunks.
+					// accumulateCounterMetrics() retains their state for the expiry window.
 					logger.error("Zone chunk query failed", {
 						query: queryName,
 						chunk_index: Math.floor(i / ZONES_PER_CHUNK),
@@ -510,6 +535,9 @@ export class MetricExporter extends DurableObject<Env> {
 				}
 			}
 
+			if (chunkResults.length === 0 && firstChunkError !== undefined) {
+				throw firstChunkError;
+			}
 			return mergeMetricDefinitions(...chunkResults);
 		}
 
@@ -547,6 +575,15 @@ export class MetricExporter extends DurableObject<Env> {
 		}
 	}
 
+	/** Persist current state in bounded storage chunks. */
+	private async saveState(): Promise<void> {
+		await saveChunkedValue(
+			chunkedDurableObjectStorage(this.ctx.storage),
+			STATE_KEY,
+			this.getState(),
+		);
+	}
+
 	/**
 	 * Return cached accumulated metrics.
 	 *
@@ -555,53 +592,5 @@ export class MetricExporter extends DurableObject<Env> {
 	async export(): Promise<MetricDefinition[]> {
 		const state = this.getState();
 		return state.metrics;
-	}
-
-	/**
-	 * Process raw metrics and accumulate counter values.
-	 *
-	 * @param rawMetrics Raw metrics from Cloudflare API.
-	 * @param existingCounters Existing counter state.
-	 * @returns Processed metrics with accumulated counter values and updated counter state.
-	 */
-	private processCounters(
-		rawMetrics: MetricDefinition[],
-		existingCounters: Record<string, CounterState>,
-	): { metrics: MetricDefinition[]; counters: Record<string, CounterState> } {
-		const newCounters: Record<string, CounterState> = { ...existingCounters };
-
-		const metrics = rawMetrics.map((metric) => {
-			if (metric.type !== "counter") {
-				return metric;
-			}
-
-			const processedValues: MetricValue[] = metric.values.map((value) => {
-				const key = metricKey(metric.name, value.labels);
-				newCounters[key] = this.updateCounter(newCounters[key], value.value);
-				return { labels: value.labels, value: newCounters[key].accumulated };
-			});
-
-			return { ...metric, values: processedValues };
-		});
-
-		return { metrics, counters: newCounters };
-	}
-
-	/**
-	 * Update counter state with a new raw value.
-	 * Cloudflare API returns window-based totals, so we simply add them.
-	 *
-	 * @param existing Existing counter state or undefined for new counter.
-	 * @param rawValue Window total from API to add to accumulated value.
-	 * @returns Updated counter state with accumulated value.
-	 */
-	private updateCounter(
-		existing: CounterState | undefined,
-		rawValue: number,
-	): CounterState {
-		if (!existing) {
-			return { accumulated: rawValue };
-		}
-		return { accumulated: existing.accumulated + rawValue };
 	}
 }

--- a/src/durable-objects/MetricExporter.ts
+++ b/src/durable-objects/MetricExporter.ts
@@ -6,6 +6,7 @@ import {
 	isZoneLevelQuery,
 } from "../cloudflare/client";
 import { isPaidTierGraphQLQuery } from "../cloudflare/queries";
+import { runAlarmWithRecovery } from "../lib/alarm-recovery";
 import {
 	chunkedDurableObjectStorage,
 	loadChunkedValue,
@@ -13,7 +14,7 @@ import {
 } from "../lib/chunked-storage";
 import { accumulateCounterMetrics } from "../lib/counters";
 import { parseCommaSeparated, partitionZonesByTier } from "../lib/filters";
-import { createLogger, type Logger } from "../lib/logger";
+import { configFromEnv, createLogger, type Logger } from "../lib/logger";
 import { getMetricRefreshDelaySeconds } from "../lib/metric-refresh";
 import {
 	type MetricDefinition,
@@ -32,6 +33,7 @@ import {
 } from "../lib/types";
 
 const STATE_KEY = "state";
+const ALARM_RECOVERY_DELAY_MS = 60 * 1000;
 
 /**
  * Maximum allowed hostnames in HOST_METRICS_ALLOWLIST.
@@ -265,14 +267,24 @@ export class MetricExporter extends DurableObject<Env> {
 	 * Triggers metric refresh and reschedules next alarm with jitter.
 	 */
 	override async alarm(): Promise<void> {
-		const config = await getConfig(this.env);
-		const logger = this.createLogger(config);
-		logger.info("Alarm fired, refreshing");
-		const timeRange = getTimeRange(
-			config.scrapeDelaySeconds,
-			config.timeWindowSeconds,
-		);
-		await this.refreshWithTimeRange(timeRange, config, logger);
+		let logger: Logger | undefined;
+
+		await runAlarmWithRecovery({
+			run: async () => {
+				logger = createLogger("metric_exporter_alarm", configFromEnv(this.env));
+				const config = await getConfig(this.env);
+				logger = this.createLogger(config);
+				logger.info("Alarm fired, refreshing");
+				const timeRange = getTimeRange(
+					config.scrapeDelaySeconds,
+					config.timeWindowSeconds,
+				);
+				await this.refreshWithTimeRange(timeRange, config, logger);
+			},
+			getLogger: () => logger,
+			scheduleRecoveryAlarm: () =>
+				this.ctx.storage.setAlarm(Date.now() + ALARM_RECOVERY_DELAY_MS),
+		});
 	}
 
 	/**

--- a/src/lib/alarm-recovery.test.ts
+++ b/src/lib/alarm-recovery.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi } from "vitest";
+import { runAlarmWithRecovery } from "./alarm-recovery";
+
+describe("alarm recovery", () => {
+	it("does not schedule a recovery alarm after a successful handler", async () => {
+		const scheduleRecoveryAlarm = vi.fn().mockResolvedValue(undefined);
+
+		await runAlarmWithRecovery({
+			run: async () => undefined,
+			getLogger: () => undefined,
+			scheduleRecoveryAlarm,
+		});
+
+		expect(scheduleRecoveryAlarm).not.toHaveBeenCalled();
+	});
+
+	it("schedules a recovery alarm and swallows the handler error", async () => {
+		const logger = { error: vi.fn() };
+		const scheduleRecoveryAlarm = vi.fn().mockResolvedValue(undefined);
+
+		await expect(
+			runAlarmWithRecovery({
+				run: async () => {
+					throw new Error("refresh failed before rescheduling");
+				},
+				getLogger: () => logger,
+				scheduleRecoveryAlarm,
+			}),
+		).resolves.toBeUndefined();
+
+		expect(scheduleRecoveryAlarm).toHaveBeenCalledOnce();
+		expect(logger.error).toHaveBeenCalledWith("Alarm handler failed", {
+			error: "refresh failed before rescheduling",
+		});
+	});
+
+	it("keeps the alarm loop alive across repeated handler failures", async () => {
+		const scheduleRecoveryAlarm = vi.fn().mockResolvedValue(undefined);
+
+		for (let attempt = 0; attempt < 10; attempt++) {
+			await runAlarmWithRecovery({
+				run: async () => {
+					throw new Error("refresh failed");
+				},
+				getLogger: () => undefined,
+				scheduleRecoveryAlarm,
+			});
+		}
+
+		expect(scheduleRecoveryAlarm).toHaveBeenCalledTimes(10);
+	});
+
+	it("still schedules recovery when error logging fails", async () => {
+		const scheduleRecoveryAlarm = vi.fn().mockResolvedValue(undefined);
+
+		await expect(
+			runAlarmWithRecovery({
+				run: async () => {
+					throw new Error("refresh failed");
+				},
+				getLogger: () => ({
+					error: () => {
+						throw new Error("logger failed");
+					},
+				}),
+				scheduleRecoveryAlarm,
+			}),
+		).resolves.toBeUndefined();
+
+		expect(scheduleRecoveryAlarm).toHaveBeenCalledOnce();
+	});
+
+	it("rethrows when the recovery alarm cannot be scheduled", async () => {
+		const scheduleError = new Error("storage unavailable");
+		const logger = { error: vi.fn() };
+
+		await expect(
+			runAlarmWithRecovery({
+				run: async () => {
+					throw new Error("refresh failed before rescheduling");
+				},
+				getLogger: () => logger,
+				scheduleRecoveryAlarm: async () => {
+					throw scheduleError;
+				},
+			}),
+		).rejects.toThrow(scheduleError);
+
+		expect(logger.error).toHaveBeenLastCalledWith(
+			"Failed to schedule recovery alarm",
+			{ error: "storage unavailable" },
+		);
+	});
+});

--- a/src/lib/alarm-recovery.ts
+++ b/src/lib/alarm-recovery.ts
@@ -1,0 +1,42 @@
+export interface AlarmRecoveryLogger {
+	error(message: string, context?: Record<string, unknown>): void;
+}
+
+function errorMessage(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
+}
+
+function logError(
+	logger: AlarmRecoveryLogger | undefined,
+	message: string,
+	error: unknown,
+): void {
+	try {
+		logger?.error(message, { error: errorMessage(error) });
+	} catch {
+		// Recovery must not depend on logging succeeding.
+	}
+}
+
+export async function runAlarmWithRecovery(options: {
+	run: () => Promise<void>;
+	getLogger: () => AlarmRecoveryLogger | undefined;
+	scheduleRecoveryAlarm: () => Promise<void>;
+}): Promise<void> {
+	try {
+		await options.run();
+	} catch (error) {
+		logError(options.getLogger(), "Alarm handler failed", error);
+
+		try {
+			await options.scheduleRecoveryAlarm();
+		} catch (scheduleError) {
+			logError(
+				options.getLogger(),
+				"Failed to schedule recovery alarm",
+				scheduleError,
+			);
+			throw scheduleError;
+		}
+	}
+}

--- a/src/lib/chunked-storage.test.ts
+++ b/src/lib/chunked-storage.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import {
+	type ChunkedValueStorage,
+	loadChunkedValue,
+	saveChunkedValue,
+} from "./chunked-storage";
+
+class SizeLimitedMemoryStorage implements ChunkedValueStorage {
+	readonly values = new Map<string, unknown>();
+	writesBeforeFailure: number | undefined;
+
+	constructor(private readonly maximumValueBytes: number) {}
+
+	async get(key: string): Promise<unknown> {
+		return this.values.get(key);
+	}
+
+	async getMany(keys: string[]): Promise<Map<string, unknown>> {
+		const values = new Map<string, unknown>();
+		for (const key of keys) {
+			if (this.values.has(key)) {
+				values.set(key, this.values.get(key));
+			}
+		}
+		return values;
+	}
+
+	async putMany(entries: Record<string, unknown>): Promise<void> {
+		if (this.writesBeforeFailure === 0) {
+			this.writesBeforeFailure = undefined;
+			throw new Error("simulated storage failure");
+		}
+		if (this.writesBeforeFailure !== undefined) {
+			this.writesBeforeFailure--;
+		}
+		for (const value of Object.values(entries)) {
+			const size =
+				value instanceof Uint8Array
+					? value.byteLength
+					: new TextEncoder().encode(JSON.stringify(value)).byteLength;
+			if (size > this.maximumValueBytes) {
+				throw new RangeError("storage value is too large");
+			}
+		}
+		for (const [key, value] of Object.entries(entries)) {
+			this.values.set(key, value);
+		}
+	}
+
+	async deleteMany(keys: string[]): Promise<void> {
+		for (const key of keys) {
+			this.values.delete(key);
+		}
+	}
+}
+
+describe("chunked storage", () => {
+	it("round-trips state larger than one storage value", async () => {
+		const storage = new SizeLimitedMemoryStorage(110_000);
+		const state = {
+			metrics: [{ name: "large", payload: "🔥".repeat(80_000) }],
+			counters: { requests: 42 },
+		};
+
+		await saveChunkedValue(storage, "state", state);
+		const restored = await loadChunkedValue(storage, "state", z.unknown());
+
+		expect(restored).toEqual(state);
+	});
+
+	it("reads state written by exporter versions before chunking", async () => {
+		const storage = new SizeLimitedMemoryStorage(110_000);
+		const legacyState = { counters: { requests: 42 } };
+		storage.values.set("state", legacyState);
+
+		expect(await loadChunkedValue(storage, "state", z.unknown())).toEqual(
+			legacyState,
+		);
+	});
+
+	it("rejects legacy state that does not match the caller's schema", async () => {
+		const storage = new SizeLimitedMemoryStorage(110_000);
+		storage.values.set("state", { counters: "corrupt" });
+		const schema = z.object({
+			counters: z.record(z.string(), z.number()),
+		});
+
+		await expect(loadChunkedValue(storage, "state", schema)).rejects.toThrow();
+	});
+
+	it("rejects a chunked value when one of its chunks is missing", async () => {
+		const storage = new SizeLimitedMemoryStorage(110_000);
+		await saveChunkedValue(storage, "state", { payload: "x".repeat(300_000) });
+		const chunkKey = [...storage.values.keys()].find((key) =>
+			key.startsWith("state:chunk:"),
+		);
+		expect(chunkKey).toBeDefined();
+		if (chunkKey !== undefined) {
+			storage.values.delete(chunkKey);
+		}
+
+		await expect(
+			loadChunkedValue(storage, "state", z.unknown()),
+		).rejects.toThrow("Missing state chunk");
+	});
+
+	it("rejects chunked state that does not match the caller's schema", async () => {
+		const storage = new SizeLimitedMemoryStorage(110_000);
+		await saveChunkedValue(storage, "state", { counters: "corrupt" });
+		const schema = z.object({
+			counters: z.record(z.string(), z.number()),
+		});
+
+		await expect(loadChunkedValue(storage, "state", schema)).rejects.toThrow();
+	});
+
+	it("replaces old chunks instead of accumulating storage generations", async () => {
+		const storage = new SizeLimitedMemoryStorage(110_000);
+		await saveChunkedValue(storage, "state", { payload: "x".repeat(300_000) });
+		await saveChunkedValue(storage, "state", { payload: "small" });
+
+		expect(await loadChunkedValue(storage, "state", z.unknown())).toEqual({
+			payload: "small",
+		});
+		expect(storage.values.size).toBe(1);
+	});
+
+	it("keeps the previous generation readable when a replacement write fails", async () => {
+		const storage = new SizeLimitedMemoryStorage(110_000);
+		await saveChunkedValue(storage, "state", { payload: "previous" });
+		storage.writesBeforeFailure = 0;
+
+		await expect(
+			saveChunkedValue(storage, "state", { payload: "replacement" }),
+		).rejects.toThrow("simulated storage failure");
+		expect(await loadChunkedValue(storage, "state", z.unknown())).toEqual({
+			payload: "previous",
+		});
+	});
+
+	it("cleans partial chunks when a failed replacement is retried", async () => {
+		const storage = new SizeLimitedMemoryStorage(110_000);
+		await saveChunkedValue(storage, "state", { payload: "previous" });
+		storage.writesBeforeFailure = 1;
+		await expect(
+			saveChunkedValue(storage, "state", { payload: "x".repeat(300_000) }),
+		).rejects.toThrow("simulated storage failure");
+
+		await saveChunkedValue(storage, "state", { payload: "replacement" });
+
+		expect(await loadChunkedValue(storage, "state", z.unknown())).toEqual({
+			payload: "replacement",
+		});
+		expect(storage.values.size).toBe(1);
+	});
+});

--- a/src/lib/chunked-storage.test.ts
+++ b/src/lib/chunked-storage.test.ts
@@ -69,6 +69,19 @@ describe("chunked storage", () => {
 		expect(restored).toEqual(state);
 	});
 
+	it("keeps the legacy base value as a rollback snapshot", async () => {
+		const storage = new SizeLimitedMemoryStorage(110_000);
+		const legacyState = { payload: "legacy" };
+		storage.values.set("state", legacyState);
+
+		await saveChunkedValue(storage, "state", { payload: "x".repeat(300_000) });
+
+		expect(storage.values.get("state")).toEqual(legacyState);
+		expect(await loadChunkedValue(storage, "state", z.unknown())).toEqual({
+			payload: "x".repeat(300_000),
+		});
+	});
+
 	it("reads state written by exporter versions before chunking", async () => {
 		const storage = new SizeLimitedMemoryStorage(110_000);
 		const legacyState = { counters: { requests: 42 } };
@@ -87,6 +100,19 @@ describe("chunked storage", () => {
 		});
 
 		await expect(loadChunkedValue(storage, "state", schema)).rejects.toThrow();
+	});
+
+	it("rejects a malformed manifest before allocating chunk keys", async () => {
+		const storage = new SizeLimitedMemoryStorage(110_000);
+		storage.values.set("state:manifest", {
+			format: "chunked-json-v1",
+			generation: 0,
+			chunks: Number.MAX_SAFE_INTEGER,
+		});
+
+		await expect(
+			loadChunkedValue(storage, "state", z.unknown()),
+		).rejects.toThrow();
 	});
 
 	it("rejects a chunked value when one of its chunks is missing", async () => {
@@ -139,7 +165,28 @@ describe("chunked storage", () => {
 		});
 	});
 
-	it("cleans partial chunks when a failed replacement is retried", async () => {
+	it("cleans chunks from a failed multi-batch write when retried", async () => {
+		const storage = new SizeLimitedMemoryStorage(110_000);
+		await saveChunkedValue(storage, "state", { payload: "previous" });
+		storage.writesBeforeFailure = 2;
+		await expect(
+			saveChunkedValue(storage, "state", {
+				payload: "x".repeat(13_200_000),
+			}),
+		).rejects.toThrow("simulated storage failure");
+		expect(
+			[...storage.values.keys()].some((key) => key.startsWith("state:chunk:")),
+		).toBe(true);
+
+		await saveChunkedValue(storage, "state", { payload: "replacement" });
+
+		expect(await loadChunkedValue(storage, "state", z.unknown())).toEqual({
+			payload: "replacement",
+		});
+		expect(storage.values.size).toBe(1);
+	});
+
+	it("cleans pending state when a failed replacement is retried", async () => {
 		const storage = new SizeLimitedMemoryStorage(110_000);
 		await saveChunkedValue(storage, "state", { payload: "previous" });
 		storage.writesBeforeFailure = 1;

--- a/src/lib/chunked-storage.ts
+++ b/src/lib/chunked-storage.ts
@@ -1,0 +1,216 @@
+import { z } from "zod";
+
+const CHUNK_BYTES = 100 * 1024;
+const MAX_KEYS_PER_OPERATION = 128;
+const FORMAT = "chunked-json-v1";
+
+const ChunkManifestSchema = z.object({
+	format: z.literal(FORMAT),
+	generation: z.number().int().nonnegative(),
+	chunks: z.number().int().positive(),
+});
+
+type ChunkManifest = z.infer<typeof ChunkManifestSchema>;
+
+export interface ChunkedValueStorage {
+	get(key: string): Promise<unknown>;
+	getMany(keys: string[]): Promise<Map<string, unknown>>;
+	putMany(entries: Record<string, unknown>): Promise<void>;
+	deleteMany(keys: string[]): Promise<void>;
+}
+
+/**
+ * Adapts Durable Object storage to the minimal interface used for chunked values.
+ */
+export function chunkedDurableObjectStorage(
+	storage: DurableObjectStorage,
+): ChunkedValueStorage {
+	return {
+		get: (key) => storage.get(key, { noCache: true }),
+		getMany: (keys) => storage.get(keys, { noCache: true }),
+		putMany: (entries) => storage.put(entries, { noCache: true }),
+		deleteMany: async (keys) => {
+			await storage.delete(keys);
+		},
+	};
+}
+
+function parseManifest(value: unknown): ChunkManifest | undefined {
+	const result = ChunkManifestSchema.safeParse(value);
+	return result.success ? result.data : undefined;
+}
+
+function chunkKey(baseKey: string, generation: number, index: number): string {
+	return `${baseKey}:chunk:${generation}:${index}`;
+}
+
+function pendingKey(baseKey: string, generation: number): string {
+	return `${baseKey}:pending:${generation}`;
+}
+
+function chunkKeys(baseKey: string, manifest: ChunkManifest): string[] {
+	return Array.from({ length: manifest.chunks }, (_, index) =>
+		chunkKey(baseKey, manifest.generation, index),
+	);
+}
+
+function batches<T>(items: T[]): T[][] {
+	const result: T[][] = [];
+	for (let index = 0; index < items.length; index += MAX_KEYS_PER_OPERATION) {
+		result.push(items.slice(index, index + MAX_KEYS_PER_OPERATION));
+	}
+	return result;
+}
+
+async function cleanupPendingGeneration(
+	storage: ChunkedValueStorage,
+	baseKey: string,
+	generation: number,
+): Promise<void> {
+	const key = pendingKey(baseKey, generation);
+	const pending = parseManifest(await storage.get(key));
+	if (pending === undefined) {
+		return;
+	}
+	for (const keyBatch of batches(chunkKeys(baseKey, pending))) {
+		await storage.deleteMany(keyBatch);
+	}
+	await storage.deleteMany([key]);
+}
+
+/**
+ * Loads a value written by saveChunkedValue, or a legacy unchunked value.
+ */
+export async function loadChunkedValue<T>(
+	storage: ChunkedValueStorage,
+	baseKey: string,
+	schema: z.ZodType<T>,
+): Promise<T | undefined> {
+	const stored = await storage.get(baseKey);
+	if (stored === undefined) {
+		return undefined;
+	}
+	const manifest = parseManifest(stored);
+	if (manifest === undefined) {
+		return schema.parse(stored);
+	}
+
+	const keys = chunkKeys(baseKey, manifest);
+	const values = new Map<string, unknown>();
+	for (const keyBatch of batches(keys)) {
+		const batchValues = await storage.getMany(keyBatch);
+		for (const [key, value] of batchValues) {
+			values.set(key, value);
+		}
+	}
+
+	const chunks = keys.map((key) => {
+		const value = values.get(key);
+		if (!(value instanceof Uint8Array)) {
+			throw new Error(`Missing state chunk: ${key}`);
+		}
+		return value;
+	});
+	const byteLength = chunks.reduce(
+		(total, chunk) => total + chunk.byteLength,
+		0,
+	);
+	const serialized = new Uint8Array(byteLength);
+	let offset = 0;
+	for (const chunk of chunks) {
+		serialized.set(chunk, offset);
+		offset += chunk.byteLength;
+	}
+
+	const parsed: unknown = JSON.parse(new TextDecoder().decode(serialized));
+	return schema.parse(parsed);
+}
+
+/**
+ * Persists a value as independently bounded chunks. A generation manifest is
+ * switched only after all new chunks exist, so readers never observe a partial
+ * write. Values written by older versions are migrated on the next save.
+ */
+export async function saveChunkedValue(
+	storage: ChunkedValueStorage,
+	baseKey: string,
+	value: unknown,
+): Promise<void> {
+	const previous = await storage.get(baseKey);
+	const previousManifest = parseManifest(previous);
+	const generation = previousManifest?.generation === 0 ? 1 : 0;
+	const json = JSON.stringify(value);
+	if (json === undefined) {
+		throw new TypeError("Chunked storage value must be JSON serializable");
+	}
+	const serialized = new TextEncoder().encode(json);
+
+	if (serialized.byteLength <= CHUNK_BYTES) {
+		if (previousManifest === undefined) {
+			await cleanupPendingGeneration(storage, baseKey, 0);
+			await cleanupPendingGeneration(storage, baseKey, 1);
+		} else {
+			await storage.putMany({
+				[pendingKey(baseKey, previousManifest.generation)]: previousManifest,
+			});
+		}
+		await storage.putMany({ [baseKey]: value });
+		if (previousManifest !== undefined) {
+			await cleanupPendingGeneration(
+				storage,
+				baseKey,
+				previousManifest.generation,
+			);
+		}
+		return;
+	}
+
+	const nextManifest: ChunkManifest = {
+		format: FORMAT,
+		generation,
+		chunks: Math.ceil(serialized.byteLength / CHUNK_BYTES),
+	};
+	const nextPendingKey = pendingKey(baseKey, generation);
+	await cleanupPendingGeneration(storage, baseKey, generation);
+
+	// Record both generations before writing chunks. If any later write or
+	// cleanup fails, the next attempt can remove all abandoned values safely.
+	await storage.putMany({
+		[nextPendingKey]: nextManifest,
+		...(previousManifest === undefined
+			? {}
+			: {
+					[pendingKey(baseKey, previousManifest.generation)]: previousManifest,
+				}),
+	});
+
+	for (
+		let firstChunk = 0;
+		firstChunk < nextManifest.chunks;
+		firstChunk += MAX_KEYS_PER_OPERATION
+	) {
+		const entries: Record<string, unknown> = {};
+		const lastChunk = Math.min(
+			firstChunk + MAX_KEYS_PER_OPERATION,
+			nextManifest.chunks,
+		);
+		for (let index = firstChunk; index < lastChunk; index++) {
+			entries[chunkKey(baseKey, generation, index)] = serialized.slice(
+				index * CHUNK_BYTES,
+				(index + 1) * CHUNK_BYTES,
+			);
+		}
+		await storage.putMany(entries);
+	}
+
+	await storage.putMany({ [baseKey]: nextManifest });
+
+	if (previousManifest !== undefined) {
+		await cleanupPendingGeneration(
+			storage,
+			baseKey,
+			previousManifest.generation,
+		);
+	}
+	await storage.deleteMany([nextPendingKey]);
+}

--- a/src/lib/chunked-storage.ts
+++ b/src/lib/chunked-storage.ts
@@ -2,12 +2,15 @@ import { z } from "zod";
 
 const CHUNK_BYTES = 100 * 1024;
 const MAX_KEYS_PER_OPERATION = 128;
+const MAX_SERIALIZED_BYTES = 16 * 1024 * 1024;
+const MAX_CHUNKS = Math.ceil(MAX_SERIALIZED_BYTES / CHUNK_BYTES);
 const FORMAT = "chunked-json-v1";
 
 const ChunkManifestSchema = z.object({
 	format: z.literal(FORMAT),
-	generation: z.number().int().nonnegative(),
-	chunks: z.number().int().positive(),
+	generation: z.union([z.literal(0), z.literal(1)]),
+	chunks: z.number().int().positive().max(MAX_CHUNKS),
+	bytes: z.number().int().positive().max(MAX_SERIALIZED_BYTES).optional(),
 });
 
 type ChunkManifest = z.infer<typeof ChunkManifestSchema>;
@@ -19,9 +22,7 @@ export interface ChunkedValueStorage {
 	deleteMany(keys: string[]): Promise<void>;
 }
 
-/**
- * Adapts Durable Object storage to the minimal interface used for chunked values.
- */
+/** Adapts Durable Object storage to the minimal chunked-value interface. */
 export function chunkedDurableObjectStorage(
 	storage: DurableObjectStorage,
 ): ChunkedValueStorage {
@@ -35,9 +36,22 @@ export function chunkedDurableObjectStorage(
 	};
 }
 
+function manifestKey(baseKey: string): string {
+	return `${baseKey}:manifest`;
+}
+
+function isChunkFormat(value: unknown): boolean {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		"format" in value &&
+		value.format === FORMAT
+	);
+}
+
 function parseManifest(value: unknown): ChunkManifest | undefined {
-	const result = ChunkManifestSchema.safeParse(value);
-	return result.success ? result.data : undefined;
+	if (!isChunkFormat(value)) return undefined;
+	return ChunkManifestSchema.parse(value);
 }
 
 function chunkKey(baseKey: string, generation: number, index: number): string {
@@ -68,82 +82,96 @@ async function cleanupPendingGeneration(
 	generation: number,
 ): Promise<void> {
 	const key = pendingKey(baseKey, generation);
-	const pending = parseManifest(await storage.get(key));
-	if (pending === undefined) {
-		return;
-	}
+	const stored = await storage.get(key);
+	if (stored === undefined) return;
+	const pending = ChunkManifestSchema.parse(stored);
 	for (const keyBatch of batches(chunkKeys(baseKey, pending))) {
 		await storage.deleteMany(keyBatch);
 	}
 	await storage.deleteMany([key]);
 }
 
-/**
- * Loads a value written by saveChunkedValue, or a legacy unchunked value.
- */
+async function readCurrentValues(
+	storage: ChunkedValueStorage,
+	baseKey: string,
+): Promise<{ base: unknown; manifest: ChunkManifest | undefined }> {
+	const pointerKey = manifestKey(baseKey);
+	const values = await storage.getMany([baseKey, pointerKey]);
+	const pointer = values.get(pointerKey);
+	if (pointer !== undefined) {
+		return {
+			base: values.get(baseKey),
+			manifest: ChunkManifestSchema.parse(pointer),
+		};
+	}
+	const base = values.get(baseKey);
+	return { base, manifest: parseManifest(base) };
+}
+
+/** Loads a chunked value, or state written by an older unchunked exporter. */
 export async function loadChunkedValue<T>(
 	storage: ChunkedValueStorage,
 	baseKey: string,
 	schema: z.ZodType<T>,
 ): Promise<T | undefined> {
-	const stored = await storage.get(baseKey);
-	if (stored === undefined) {
-		return undefined;
-	}
-	const manifest = parseManifest(stored);
-	if (manifest === undefined) {
-		return schema.parse(stored);
+	const current = await readCurrentValues(storage, baseKey);
+	if (current.manifest === undefined) {
+		return current.base === undefined ? undefined : schema.parse(current.base);
 	}
 
-	const keys = chunkKeys(baseKey, manifest);
-	const values = new Map<string, unknown>();
+	const decoder = new TextDecoder();
+	const keys = chunkKeys(baseKey, current.manifest);
+	let serialized = "";
+	let byteLength = 0;
 	for (const keyBatch of batches(keys)) {
-		const batchValues = await storage.getMany(keyBatch);
-		for (const [key, value] of batchValues) {
-			values.set(key, value);
+		const values = await storage.getMany(keyBatch);
+		for (const key of keyBatch) {
+			const value = values.get(key);
+			if (!(value instanceof Uint8Array)) {
+				throw new Error(`Missing state chunk: ${key}`);
+			}
+			byteLength += value.byteLength;
+			if (byteLength > MAX_SERIALIZED_BYTES) {
+				throw new RangeError(
+					"Chunked storage value exceeds the safe size limit",
+				);
+			}
+			serialized += decoder.decode(value, { stream: true });
 		}
 	}
-
-	const chunks = keys.map((key) => {
-		const value = values.get(key);
-		if (!(value instanceof Uint8Array)) {
-			throw new Error(`Missing state chunk: ${key}`);
-		}
-		return value;
-	});
-	const byteLength = chunks.reduce(
-		(total, chunk) => total + chunk.byteLength,
-		0,
-	);
-	const serialized = new Uint8Array(byteLength);
-	let offset = 0;
-	for (const chunk of chunks) {
-		serialized.set(chunk, offset);
-		offset += chunk.byteLength;
+	serialized += decoder.decode();
+	if (
+		current.manifest.bytes !== undefined &&
+		byteLength !== current.manifest.bytes
+	) {
+		throw new Error("Chunked storage value has an invalid byte length");
 	}
 
-	const parsed: unknown = JSON.parse(new TextDecoder().decode(serialized));
+	const parsed: unknown = JSON.parse(serialized);
 	return schema.parse(parsed);
 }
 
 /**
- * Persists a value as independently bounded chunks. A generation manifest is
- * switched only after all new chunks exist, so readers never observe a partial
- * write. Values written by older versions are migrated on the next save.
+ * Persists a value in bounded chunks and atomically switches a manifest pointer.
+ * The legacy base value is retained while state is large, allowing rollback to an
+ * older exporter to load the last small valid snapshot.
  */
 export async function saveChunkedValue(
 	storage: ChunkedValueStorage,
 	baseKey: string,
 	value: unknown,
 ): Promise<void> {
-	const previous = await storage.get(baseKey);
-	const previousManifest = parseManifest(previous);
+	const current = await readCurrentValues(storage, baseKey);
+	const previousManifest = current.manifest;
 	const generation = previousManifest?.generation === 0 ? 1 : 0;
 	const json = JSON.stringify(value);
 	if (json === undefined) {
 		throw new TypeError("Chunked storage value must be JSON serializable");
 	}
 	const serialized = new TextEncoder().encode(json);
+	if (serialized.byteLength > MAX_SERIALIZED_BYTES) {
+		throw new RangeError("Chunked storage value exceeds the safe size limit");
+	}
 
 	if (serialized.byteLength <= CHUNK_BYTES) {
 		if (previousManifest === undefined) {
@@ -155,6 +183,7 @@ export async function saveChunkedValue(
 			});
 		}
 		await storage.putMany({ [baseKey]: value });
+		await storage.deleteMany([manifestKey(baseKey)]);
 		if (previousManifest !== undefined) {
 			await cleanupPendingGeneration(
 				storage,
@@ -169,12 +198,16 @@ export async function saveChunkedValue(
 		format: FORMAT,
 		generation,
 		chunks: Math.ceil(serialized.byteLength / CHUNK_BYTES),
+		bytes: serialized.byteLength,
 	};
 	const nextPendingKey = pendingKey(baseKey, generation);
-	await cleanupPendingGeneration(storage, baseKey, generation);
+	if (previousManifest === undefined) {
+		await cleanupPendingGeneration(storage, baseKey, 0);
+		await cleanupPendingGeneration(storage, baseKey, 1);
+	} else {
+		await cleanupPendingGeneration(storage, baseKey, generation);
+	}
 
-	// Record both generations before writing chunks. If any later write or
-	// cleanup fails, the next attempt can remove all abandoned values safely.
 	await storage.putMany({
 		[nextPendingKey]: nextManifest,
 		...(previousManifest === undefined
@@ -203,7 +236,7 @@ export async function saveChunkedValue(
 		await storage.putMany(entries);
 	}
 
-	await storage.putMany({ [baseKey]: nextManifest });
+	await storage.putMany({ [manifestKey(baseKey)]: nextManifest });
 
 	if (previousManifest !== undefined) {
 		await cleanupPendingGeneration(

--- a/src/lib/counters.test.ts
+++ b/src/lib/counters.test.ts
@@ -45,6 +45,71 @@ describe("accumulateCounterMetrics", () => {
 		expect(secondRefresh.metrics[0]?.values[0]?.value).toBe(50);
 	});
 
+	it("aggregates duplicate observations before accumulating", () => {
+		const counter: MetricDefinition = {
+			name: "cloudflare_requests_total",
+			help: "Total requests",
+			type: "counter",
+			values: [
+				{ labels: { zone: "example.com" }, value: 3 },
+				{ labels: { zone: "example.com" }, value: 4 },
+			],
+		};
+
+		const result = accumulateCounterMetrics([counter], {});
+
+		expect(result.metrics[0]?.values).toEqual([
+			{ labels: { zone: "example.com" }, value: 7 },
+		]);
+	});
+
+	it("does not accumulate the same query window twice", () => {
+		const counter: MetricDefinition = {
+			name: "cloudflare_requests_total",
+			help: "Total requests",
+			type: "counter",
+			values: [{ labels: { zone: "example.com" }, value: 42 }],
+		};
+		const first = accumulateCounterMetrics([counter], {}, { ingestId: 123 });
+		const replay = accumulateCounterMetrics([counter], first.counters, {
+			ingestId: 123,
+			ageMissingCounters: false,
+		});
+
+		expect(replay.metrics[0]?.values[0]?.value).toBe(42);
+		expect(replay.counters).toEqual(first.counters);
+	});
+
+	it("ages successful scopes but not failed scopes during a partial refresh", () => {
+		const failedKey = "cloudflare_requests_total{zone=failed.example.com}";
+		const successfulKey =
+			"cloudflare_requests_total{zone=successful.example.com}";
+		const result = accumulateCounterMetrics(
+			[],
+			{
+				[failedKey]: {
+					accumulated: 42,
+					missesRemaining: 5,
+					lastIngest: 123,
+					scope: "failed.example.com",
+				},
+				[successfulKey]: {
+					accumulated: 7,
+					missesRemaining: 5,
+					lastIngest: 123,
+					scope: "successful.example.com",
+				},
+			},
+			{
+				ingestId: 124,
+				failedScopes: new Set(["failed.example.com"]),
+			},
+		);
+
+		expect(result.counters[failedKey]?.missesRemaining).toBe(5);
+		expect(result.counters[successfulKey]?.missesRemaining).toBe(4);
+	});
+
 	it("passes gauges through without retaining counter state", () => {
 		const gauge: MetricDefinition = {
 			name: "cloudflare_active_connections",
@@ -111,6 +176,20 @@ describe("accumulateCounterMetrics", () => {
 		result = accumulateCounterMetrics([counter], result.counters);
 
 		expect(result.metrics[0]?.values[0]?.value).toBe(8);
+	});
+
+	it("protects legacy zone counters during a partial chunk failure", () => {
+		const key = "cloudflare_requests_total{zone=failed.example.com}";
+		const result = accumulateCounterMetrics(
+			[],
+			{ [key]: { accumulated: 42 } },
+			{ failedScopes: new Set(["failed.example.com"]) },
+		);
+
+		expect(result.counters[key]).toEqual({
+			accumulated: 42,
+			scope: "failed.example.com",
+		});
 	});
 
 	it("expires counter state written before stale-series tracking was added", () => {

--- a/src/lib/counters.test.ts
+++ b/src/lib/counters.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from "vitest";
+import { accumulateCounterMetrics } from "./counters";
+import type { MetricDefinition } from "./metrics";
+
+describe("accumulateCounterMetrics", () => {
+	it("exports a counter series the first time it is observed", () => {
+		const rawMetrics: MetricDefinition[] = [
+			{
+				name: "cloudflare_requests_total",
+				help: "Total requests",
+				type: "counter",
+				values: [
+					{
+						labels: { country: "US", zone: "example.com" },
+						value: 42,
+					},
+				],
+			},
+		];
+
+		const result = accumulateCounterMetrics(rawMetrics, {});
+
+		expect(result.metrics).toEqual(rawMetrics);
+		expect(
+			result.counters["cloudflare_requests_total{country=US,zone=example.com}"]
+				?.accumulated,
+		).toBe(42);
+	});
+
+	it("accumulates repeated counter observations", () => {
+		const counter: MetricDefinition = {
+			name: "cloudflare_requests_total",
+			help: "Total requests",
+			type: "counter",
+			values: [{ labels: { zone: "example.com" }, value: 42 }],
+		};
+		const firstRefresh = accumulateCounterMetrics([counter], {});
+
+		counter.values[0] = { labels: { zone: "example.com" }, value: 8 };
+		const secondRefresh = accumulateCounterMetrics(
+			[counter],
+			firstRefresh.counters,
+		);
+
+		expect(secondRefresh.metrics[0]?.values[0]?.value).toBe(50);
+	});
+
+	it("passes gauges through without retaining counter state", () => {
+		const gauge: MetricDefinition = {
+			name: "cloudflare_active_connections",
+			help: "Current active connections",
+			type: "gauge",
+			values: [{ labels: { zone: "example.com" }, value: 7 }],
+		};
+
+		const result = accumulateCounterMetrics([gauge], {});
+
+		expect(result.metrics).toEqual([gauge]);
+		expect(result.counters).toEqual({});
+	});
+
+	it("expires a counter after five consecutive refreshes without an observation", () => {
+		const counter: MetricDefinition = {
+			name: "cloudflare_requests_total",
+			help: "Total requests",
+			type: "counter",
+			values: [{ labels: { zone: "example.com" }, value: 42 }],
+		};
+		const key = "cloudflare_requests_total{zone=example.com}";
+		let result = accumulateCounterMetrics([counter], {});
+
+		for (let missedRefreshes = 1; missedRefreshes < 5; missedRefreshes++) {
+			result = accumulateCounterMetrics([], result.counters);
+			expect(result.counters[key]?.accumulated).toBe(42);
+		}
+
+		result = accumulateCounterMetrics([], result.counters);
+		expect(result.counters[key]).toBeUndefined();
+	});
+
+	it("continues an accumulated counter when it reappears before expiry", () => {
+		const counter: MetricDefinition = {
+			name: "cloudflare_requests_total",
+			help: "Total requests",
+			type: "counter",
+			values: [{ labels: { zone: "example.com" }, value: 42 }],
+		};
+		let result = accumulateCounterMetrics([counter], {});
+		result = accumulateCounterMetrics([], result.counters);
+		result = accumulateCounterMetrics([], result.counters);
+
+		counter.values[0] = { labels: { zone: "example.com" }, value: 8 };
+		result = accumulateCounterMetrics([counter], result.counters);
+
+		expect(result.metrics[0]?.values[0]?.value).toBe(50);
+	});
+
+	it("starts a new counter when a series reappears after expiry", () => {
+		const counter: MetricDefinition = {
+			name: "cloudflare_requests_total",
+			help: "Total requests",
+			type: "counter",
+			values: [{ labels: { zone: "example.com" }, value: 42 }],
+		};
+		let result = accumulateCounterMetrics([counter], {});
+		for (let missedRefreshes = 1; missedRefreshes <= 5; missedRefreshes++) {
+			result = accumulateCounterMetrics([], result.counters);
+		}
+
+		counter.values[0] = { labels: { zone: "example.com" }, value: 8 };
+		result = accumulateCounterMetrics([counter], result.counters);
+
+		expect(result.metrics[0]?.values[0]?.value).toBe(8);
+	});
+
+	it("expires counter state written before stale-series tracking was added", () => {
+		const key = "cloudflare_requests_total{zone=example.com}";
+		let result = accumulateCounterMetrics([], {
+			[key]: { accumulated: 42 },
+		});
+
+		for (let missedRefreshes = 2; missedRefreshes <= 5; missedRefreshes++) {
+			result = accumulateCounterMetrics([], result.counters);
+		}
+
+		expect(result.counters[key]).toBeUndefined();
+	});
+
+	it("bounds retained state when labels continually churn", () => {
+		let counters = {};
+
+		for (let refresh = 0; refresh < 20; refresh++) {
+			const metric: MetricDefinition = {
+				name: "cloudflare_requests_total",
+				help: "Total requests",
+				type: "counter",
+				values: Array.from({ length: 10 }, (_, series) => ({
+					labels: { series: `${refresh}-${series}` },
+					value: 1,
+				})),
+			};
+
+			counters = accumulateCounterMetrics([metric], counters).counters;
+		}
+
+		expect(Object.keys(counters)).toHaveLength(50);
+	});
+});

--- a/src/lib/counters.ts
+++ b/src/lib/counters.ts
@@ -7,18 +7,33 @@ export type CounterProcessingResult = {
 	counters: Record<string, CounterState>;
 };
 
+export type CounterProcessingOptions = {
+	/** Stable identifier for the Cloudflare query window being accumulated. */
+	ingestId?: number;
+	/** False when replaying a window where absence is not authoritative. */
+	ageMissingCounters?: boolean;
+	/** Zone labels whose query failed and therefore must not age this refresh. */
+	failedScopes?: ReadonlySet<string>;
+};
+
 const DEFAULT_STALE_COUNTER_MISSES = 5;
+
+function zoneScopeFromMetricKey(key: string): string | undefined {
+	return /(?:\{|,)zone=([^,}]*)/.exec(key)?.[1];
+}
 
 /**
  * Converts window-based counter observations into accumulated Prometheus counters.
  *
  * @param rawMetrics Metrics returned for the current query window.
  * @param existingCounters Previously accumulated counter state.
+ * @param options Query-window and partial-failure context.
  * @returns Metrics ready for export and updated counter state.
  */
 export function accumulateCounterMetrics(
 	rawMetrics: MetricDefinition[],
 	existingCounters: Record<string, CounterState>,
+	options: CounterProcessingOptions = {},
 ): CounterProcessingResult {
 	const counters: Record<string, CounterState> = {};
 	const metrics = rawMetrics.map((metric) => {
@@ -26,16 +41,37 @@ export function accumulateCounterMetrics(
 			return metric;
 		}
 
-		const values: MetricValue[] = metric.values.map((value) => {
+		const observations = new Map<string, MetricValue>();
+		for (const value of metric.values) {
 			const key = metricKey(metric.name, value.labels);
+			const existing = observations.get(key);
+			if (existing === undefined) {
+				observations.set(key, { labels: value.labels, value: value.value });
+			} else {
+				existing.value += value.value;
+			}
+		}
+
+		const values: MetricValue[] = [];
+		for (const [key, value] of observations) {
+			const existing = existingCounters[key];
+			const alreadyIngested =
+				options.ingestId !== undefined &&
+				existing?.lastIngest === options.ingestId;
 			const accumulated =
-				(existingCounters[key]?.accumulated ?? 0) + value.value;
+				(existing?.accumulated ?? 0) + (alreadyIngested ? 0 : value.value);
 			counters[key] = {
 				accumulated,
 				missesRemaining: DEFAULT_STALE_COUNTER_MISSES,
+				...(options.ingestId === undefined
+					? {}
+					: { lastIngest: options.ingestId }),
+				...(value.labels.zone === undefined
+					? {}
+					: { scope: value.labels.zone }),
 			};
-			return { labels: value.labels, value: accumulated };
-		});
+			values.push({ labels: value.labels, value: accumulated });
+		}
 
 		return { ...metric, values };
 	});
@@ -45,11 +81,23 @@ export function accumulateCounterMetrics(
 			continue;
 		}
 
+		const scope = state.scope ?? zoneScopeFromMetricKey(key);
+		if (
+			options.ageMissingCounters === false ||
+			(options.failedScopes !== undefined &&
+				options.failedScopes.size > 0 &&
+				(scope === undefined || options.failedScopes.has(scope)))
+		) {
+			counters[key] = scope === undefined ? state : { ...state, scope };
+			continue;
+		}
+
 		const missesRemaining =
 			state.missesRemaining ?? DEFAULT_STALE_COUNTER_MISSES;
 		if (missesRemaining > 1) {
 			counters[key] = {
-				accumulated: state.accumulated,
+				...state,
+				...(scope === undefined ? {} : { scope }),
 				missesRemaining: missesRemaining - 1,
 			};
 		}

--- a/src/lib/counters.ts
+++ b/src/lib/counters.ts
@@ -1,0 +1,59 @@
+import type { MetricDefinition, MetricValue } from "./metrics";
+import { metricKey } from "./time";
+import type { CounterState } from "./types";
+
+export type CounterProcessingResult = {
+	metrics: MetricDefinition[];
+	counters: Record<string, CounterState>;
+};
+
+const DEFAULT_STALE_COUNTER_MISSES = 5;
+
+/**
+ * Converts window-based counter observations into accumulated Prometheus counters.
+ *
+ * @param rawMetrics Metrics returned for the current query window.
+ * @param existingCounters Previously accumulated counter state.
+ * @returns Metrics ready for export and updated counter state.
+ */
+export function accumulateCounterMetrics(
+	rawMetrics: MetricDefinition[],
+	existingCounters: Record<string, CounterState>,
+): CounterProcessingResult {
+	const counters: Record<string, CounterState> = {};
+	const metrics = rawMetrics.map((metric) => {
+		if (metric.type !== "counter") {
+			return metric;
+		}
+
+		const values: MetricValue[] = metric.values.map((value) => {
+			const key = metricKey(metric.name, value.labels);
+			const accumulated =
+				(existingCounters[key]?.accumulated ?? 0) + value.value;
+			counters[key] = {
+				accumulated,
+				missesRemaining: DEFAULT_STALE_COUNTER_MISSES,
+			};
+			return { labels: value.labels, value: accumulated };
+		});
+
+		return { ...metric, values };
+	});
+
+	for (const [key, state] of Object.entries(existingCounters)) {
+		if (Object.hasOwn(counters, key)) {
+			continue;
+		}
+
+		const missesRemaining =
+			state.missesRemaining ?? DEFAULT_STALE_COUNTER_MISSES;
+		if (missesRemaining > 1) {
+			counters[key] = {
+				accumulated: state.accumulated,
+				missesRemaining: missesRemaining - 1,
+			};
+		}
+	}
+
+	return { metrics, counters };
+}

--- a/src/lib/metric-refresh.test.ts
+++ b/src/lib/metric-refresh.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { GraphQLError } from "./errors";
+import { getMetricRefreshDelaySeconds } from "./metric-refresh";
+
+describe("getMetricRefreshDelaySeconds", () => {
+	it("backs off access-denied queries for one hour", () => {
+		const error = new GraphQLError("access denied", [
+			{
+				message: "account does not have access to the path",
+				extensions: { code: "FORBIDDEN" },
+			},
+		]);
+
+		expect(getMetricRefreshDelaySeconds(error, 60)).toBe(3_600);
+	});
+
+	it("uses the normal interval for transient failures", () => {
+		expect(getMetricRefreshDelaySeconds(new Error("timeout"), 60)).toBe(60);
+	});
+});

--- a/src/lib/metric-refresh.ts
+++ b/src/lib/metric-refresh.ts
@@ -1,0 +1,21 @@
+import { CloudflarePrometheusError, ErrorCode } from "./errors";
+
+const ACCESS_DENIED_RETRY_SECONDS = 60 * 60;
+
+/**
+ * Selects the next refresh delay after a failed metrics query.
+ * Access-denied products are retried infrequently so newly granted access is
+ * discovered without issuing a failing API request every minute.
+ */
+export function getMetricRefreshDelaySeconds(
+	error: unknown,
+	defaultDelaySeconds: number,
+): number {
+	if (
+		error instanceof CloudflarePrometheusError &&
+		error.code === ErrorCode.GRAPHQL_FIELD_ACCESS
+	) {
+		return Math.max(defaultDelaySeconds, ACCESS_DENIED_RETRY_SECONDS);
+	}
+	return defaultDelaySeconds;
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -54,6 +54,10 @@ export const CounterStateSchema = z
 		 * Optional so state written by earlier exporter versions can be migrated.
 		 */
 		missesRemaining: z.number().int().nonnegative().optional(),
+		/** Query-window identifier last accumulated for at-least-once safety. */
+		lastIngest: z.number().int().nonnegative().optional(),
+		/** Zone label used to isolate expiry during partial query failures. */
+		scope: z.string().optional(),
 	})
 	.readonly();
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -43,12 +43,17 @@ export const MetricExporterIdSchema = z
 export type MetricExporterId = z.infer<typeof MetricExporterIdSchema>;
 
 /**
- * Zod schema for counter state tracking accumulated total.
- * Cloudflare API returns window-based totals, so we just sum them.
+ * Zod schema for accumulated counter state and stale-series expiry.
+ * Cloudflare API returns window-based totals, so observed values are summed.
  */
 export const CounterStateSchema = z
 	.object({
 		accumulated: z.number(),
+		/**
+		 * Refreshes this series may remain unobserved before it is discarded.
+		 * Optional so state written by earlier exporter versions can be migrated.
+		 */
+		missesRemaining: z.number().int().nonnegative().optional(),
 	})
 	.readonly();
 

--- a/src/test/cloudflare-workers.ts
+++ b/src/test/cloudflare-workers.ts
@@ -1,0 +1,9 @@
+export class DurableObject<Env = unknown> {
+	protected readonly ctx: DurableObjectState;
+	protected readonly env: Env;
+
+	constructor(ctx: DurableObjectState, env: Env) {
+		this.ctx = ctx;
+		this.env = env;
+	}
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	resolve: {
+		alias: {
+			"cloudflare:workers": new URL(
+				"./src/test/cloudflare-workers.ts",
+				import.meta.url,
+			).pathname,
+		},
+	},
+});


### PR DESCRIPTION
## Summary

- expire counter series after five missed refreshes while preserving monotonic accumulation during brief gaps
- correctly pass gauges through and export newly observed counters immediately
- persist oversized MetricExporter snapshots in validated, bounded chunks with atomic generation switching and legacy-state migration
- surface GraphQL access errors and retry denied product queries hourly instead of every refresh interval
- recover the MetricExporter alarm loop after any uncaught handler failure so refreshes cannot silently stop
- add Vitest coverage, typechecking, and pull-request CI

## Motivation

MetricExporter retained every counter label set it had ever observed and persisted the complete metrics/counter snapshot under one Durable Object storage value. Label churn could therefore cause unbounded memory/storage growth and eventually oversized writes.

A failed alarm could also exhaust Cloudflare's finite platform retries before the application scheduled its next alarm. The Worker would remain available but continue serving stale metrics indefinitely. The top-level alarm recovery path now schedules a fallback alarm one minute later after any unexpected failure. If fallback scheduling itself fails, the error is rethrown so platform retries still apply.

GraphQL products unavailable to an account were also treated as successful empty responses and queried every minute.

## Testing

- `bun install --frozen-lockfile`
- `bun run check`
- `bun run typecheck`
- `bun run test` (34 tests)
- repeated alarm-failure regression (10 consecutive failures each schedule recovery)
- `wrangler deploy --dry-run` with a temporary valid KV namespace ID

Closes #28
