### PR TITLE
fix: stream /metrics response to avoid 32 MiB Workers RPC return limit

### DIFF
--- a/src/durable-objects/MetricCoordinator.ts
+++ b/src/durable-objects/MetricCoordinator.ts
@@ -4,7 +4,7 @@ import { extractErrorInfo } from "../lib/errors";
 import { filterAccountsByIds, parseCommaSeparated } from "../lib/filters";
 import { createLogger, type Logger } from "../lib/logger";
 import type { MetricDefinition } from "../lib/metrics";
-import { serializeToPrometheus } from "../lib/prometheus";
+import { serializeToPrometheus, textToStream } from "../lib/prometheus";
 import { getConfig, type ResolvedConfig } from "../lib/runtime-config";
 import type { Account } from "../lib/types";
 import { AccountMetricCoordinator } from "./AccountMetricCoordinator";
@@ -139,9 +139,13 @@ export class MetricCoordinator extends DurableObject<Env> {
 	/**
 	 * Collects metrics from all accounts and serializes to Prometheus format.
 	 *
-	 * @returns Prometheus-formatted metrics string.
+	 * Returns a byte stream rather than a string: the aggregated payload now
+	 * exceeds the 32 MiB Workers RPC return-value limit, and a streamed
+	 * ReadableStream is not subject to that cap.
+	 *
+	 * @returns Prometheus-formatted metrics as a UTF-8 byte stream.
 	 */
-	async export(): Promise<string> {
+	async export(): Promise<ReadableStream<Uint8Array>> {
 		const config = await getConfig(this.env);
 		const logger = this.createLogger(config);
 
@@ -150,7 +154,7 @@ export class MetricCoordinator extends DurableObject<Env> {
 
 		if (accounts.length === 0) {
 			logger.warn("No accounts found");
-			return "";
+			return textToStream("");
 		}
 
 		logger.info("Exporting metrics", { account_count: accounts.length });
@@ -224,10 +228,11 @@ export class MetricCoordinator extends DurableObject<Env> {
 		);
 
 		const metricsDenylist = parseCommaSeparated(config.metricsDenylist);
-		return serializeToPrometheus([...exporterMetrics, ...allMetrics], {
+		const text = serializeToPrometheus([...exporterMetrics, ...allMetrics], {
 			denylist: metricsDenylist,
 			excludeLabels: config.excludeHost ? new Set(["host"]) : undefined,
 		});
+		return textToStream(text);
 	}
 
 	/**

--- a/src/lib/prometheus.test.ts
+++ b/src/lib/prometheus.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { textToStream } from "./prometheus";
+
+async function collect(
+	stream: ReadableStream<Uint8Array>,
+): Promise<Uint8Array> {
+	const reader = stream.getReader();
+	const chunks: Uint8Array[] = [];
+	let total = 0;
+	for (;;) {
+		const { done, value } = await reader.read();
+		if (done) {
+			break;
+		}
+		chunks.push(value);
+		total += value.length;
+	}
+	const out = new Uint8Array(total);
+	let offset = 0;
+	for (const chunk of chunks) {
+		out.set(chunk, offset);
+		offset += chunk.length;
+	}
+	return out;
+}
+
+async function countChunks(
+	stream: ReadableStream<Uint8Array>,
+): Promise<number> {
+	const reader = stream.getReader();
+	let count = 0;
+	for (;;) {
+		const { done } = await reader.read();
+		if (done) {
+			break;
+		}
+		count += 1;
+	}
+	return count;
+}
+
+describe("textToStream", () => {
+	it("streams an empty string as an empty byte stream", async () => {
+		const bytes = await collect(textToStream(""));
+		expect(bytes.length).toBe(0);
+	});
+
+	it("round-trips content byte-for-byte", async () => {
+		const text = Array.from(
+			{ length: 5000 },
+			(_, i) => `metric_${i} ${i}`,
+		).join("\n");
+		const bytes = await collect(textToStream(text, 1024));
+		expect(new TextDecoder().decode(bytes)).toBe(text);
+	});
+
+	it("emits multiple chunks when the payload exceeds the target size", async () => {
+		const text = Array.from({ length: 1000 }, () => "x".repeat(100)).join("\n");
+		const chunks = await countChunks(textToStream(text, 1024));
+		expect(chunks).toBeGreaterThan(1);
+	});
+
+	it("never splits a multi-byte code point across chunks", async () => {
+		const text = Array.from({ length: 2000 }, (_, i) => `☃ line ${i}`).join(
+			"\n",
+		);
+		const bytes = await collect(textToStream(text, 64));
+		const decoded = new TextDecoder("utf-8", {
+			fatal: true,
+			ignoreBOM: false,
+		}).decode(bytes);
+		expect(decoded).toBe(text);
+	});
+});

--- a/src/lib/prometheus.ts
+++ b/src/lib/prometheus.ts
@@ -81,6 +81,49 @@ export function serializeToPrometheus(
 }
 
 /**
+ * Streams a string as UTF-8 byte chunks split on newline boundaries.
+ *
+ * Workers RPC caps a single serialized return value at 32 MiB, which the full
+ * metrics payload now exceeds. A returned ReadableStream is exempt from that cap
+ * because it is streamed rather than buffered into the RPC message. Splitting on
+ * newline boundaries keeps every chunk valid UTF-8 (a newline never falls inside
+ * a multi-byte code point) and avoids holding a second full-size copy of the
+ * payload in memory.
+ *
+ * @param text Full text to stream.
+ * @param targetChunkChars Approximate chunk size in characters (default 1 MiB).
+ * @returns Byte stream of the input text.
+ */
+export function textToStream(
+	text: string,
+	targetChunkChars = 1024 * 1024,
+): ReadableStream<Uint8Array> {
+	const encoder = new TextEncoder();
+	const length = text.length;
+	let pos = 0;
+
+	return new ReadableStream<Uint8Array>({
+		pull(controller) {
+			if (pos >= length) {
+				controller.close();
+				return;
+			}
+
+			let end = Math.min(pos + targetChunkChars, length);
+			// Extend to the next newline so chunks never split a code point.
+			if (end < length) {
+				const nextNewline = text.indexOf("\n", end);
+				end = nextNewline === -1 ? length : nextNewline + 1;
+			}
+
+			const chunk = text.slice(pos, end);
+			pos = end;
+			controller.enqueue(encoder.encode(chunk));
+		},
+	});
+}
+
+/**
  * Aggregates metric values with identical labels.
  * Counters are summed; gauges take the maximum value.
  *

--- a/src/worker.tsx
+++ b/src/worker.tsx
@@ -89,8 +89,9 @@ app.get(env.METRICS_PATH, async (c) => {
 		const coordinator = await MetricCoordinator.get(c.env);
 		const output = await coordinator.export();
 		logger.info("Metrics exported successfully");
-		return c.text(output, 200, {
-			"Content-Type": "text/plain; charset=utf-8",
+		return new Response(output, {
+			status: 200,
+			headers: { "Content-Type": "text/plain; charset=utf-8" },
 		});
 	} catch (error) {
 		const message = error instanceof Error ? error.message : String(error);


### PR DESCRIPTION
## Problem

On accounts with a large metric surface (many zones/hosts, `EXCLUDE_HOST=false`), `GET /metrics` intermittently returns HTTP 500 (`Failed to collect metrics`). The failure originates in the RPC return from `MetricCoordinator.export()`: the serialized Prometheus payload exceeds the **32 MiB Workers RPC single-return-value limit** (https://developers.cloudflare.com/workers/platform/limits/). Once the aggregate crosses ~32 MiB, every scrape 500s.

## Fix

Return the payload from `MetricCoordinator.export()` as a `ReadableStream<Uint8Array>` instead of a `string` — a streamed body is not subject to the 32 MiB single-return cap. A small `textToStream()` helper encodes the text and emits ~1 MiB chunks split on newline boundaries, so no chunk splits a multi-byte UTF-8 code point and we never
hold a second full-size copy of the payload in memory. `worker.tsx` returns `new Response(stream, …)` directly.

Output is byte-identical to the previous string response; only the transport changes. No config or API-surface changes.

## Changes

- `src/lib/prometheus.ts`: add `textToStream()`
- `src/durable-objects/MetricCoordinator.ts`: `export()` returns a UTF-8 byte stream
- `src/worker.tsx`: stream the response
- `src/lib/prometheus.test.ts`: unit tests (round-trip, multi-chunk, multi-byte safety)

## Verification

- `bun run check` (biome) clean
- `bun run typecheck` clean
- `bun run test` — new `textToStream` tests pass
