### PR TITLE
fix: query each Network Analytics dataset independently to avoid null…

### DIFF
--- a/src/cloudflare/client.test.ts
+++ b/src/cloudflare/client.test.ts
@@ -20,7 +20,6 @@ describe("CloudflareMetricsClient", () => {
 		"magic-transit-slo",
 		"magic-transit-traffic",
 		"magic-firewall-samples",
-		"network-analytics",
 		"stream-video-playback",
 		"stream-live-inputs",
 	] as const)("surfaces %s access denial instead of reporting an empty refresh", async (query) => {
@@ -44,6 +43,97 @@ describe("CloudflareMetricsClient", () => {
 				maxtime: "2026-01-01T00:01:00.000Z",
 			}),
 		).rejects.toMatchObject({ code: ErrorCode.GRAPHQL_FIELD_ACCESS });
+	});
+
+	// Network-analytics diverges from the other account queries: each NAv2
+	// dataset is queried independently so a per-dataset access denial does NOT
+	// throw away the datasets the account IS entitled to (this avoids GraphQL
+	// null-bubbling collapsing the whole combined response). A denied dataset is
+	// skipped and cached, never surfaced as a thrown error.
+	it("skips access-denied network-analytics datasets without throwing", async () => {
+		const fetch: typeof globalThis.fetch = async () =>
+			new Response(
+				JSON.stringify({
+					errors: [
+						{
+							message: "account does not have access to the path",
+							extensions: { code: "FORBIDDEN" },
+						},
+					],
+				}),
+				{ headers: { "content-type": "application/json" } },
+			);
+		const client = createClient(fetch);
+
+		await expect(
+			client.getAccountMetrics("network-analytics", "account-id", "Account", {
+				mintime: "2026-01-01T00:00:00.000Z",
+				maxtime: "2026-01-01T00:01:00.000Z",
+			}),
+		).resolves.toEqual([]);
+	});
+
+	it("returns entitled network-analytics datasets when others are denied", async () => {
+		const fetch: typeof globalThis.fetch = async (_input, init) => {
+			const body = String(init?.body ?? "");
+			// Only Magic Transit is entitled; every other dataset is denied.
+			if (body.includes("NetworkAnalyticsMagicTransit")) {
+				return new Response(
+					JSON.stringify({
+						data: {
+							viewer: {
+								accounts: [
+									{
+										magicTransitNetworkAnalyticsAdaptiveGroups: [
+											{
+												sum: { bits: 100, packets: 5 },
+												dimensions: {
+													outcome: "pass",
+													direction: "ingress",
+													ipProtocolName: "tcp",
+													mitigationSystem: "flowtrackd",
+												},
+											},
+										],
+									},
+								],
+							},
+						},
+					}),
+					{ headers: { "content-type": "application/json" } },
+				);
+			}
+			return new Response(
+				JSON.stringify({
+					errors: [
+						{
+							message: "account does not have access to the path",
+							extensions: { code: "FORBIDDEN" },
+						},
+					],
+				}),
+				{ headers: { "content-type": "application/json" } },
+			);
+		};
+		const client = createClient(fetch);
+
+		const metrics = await client.getAccountMetrics(
+			"network-analytics",
+			"account-id",
+			"Account",
+			{
+				mintime: "2026-01-01T00:00:00.000Z",
+				maxtime: "2026-01-01T00:01:00.000Z",
+			},
+		);
+
+		const names = metrics.map((m) => m.name);
+		expect(names).toContain(
+			"cloudflare_network_analytics_magic_transit_bits_total",
+		);
+		expect(names).toContain(
+			"cloudflare_network_analytics_magic_transit_packets_total",
+		);
 	});
 
 	it("allows a successful query with no observations", async () => {

--- a/src/cloudflare/client.ts
+++ b/src/cloudflare/client.ts
@@ -38,7 +38,12 @@ import {
 	MagicTransitMetricsQuery,
 	MagicTransitSLOMetricsQuery,
 	MagicTransitTunnelTrafficQuery,
-	NetworkAnalyticsQuery,
+	NetworkAnalyticsDnsProtectionQuery,
+	NetworkAnalyticsDosdQuery,
+	NetworkAnalyticsIDPSQuery,
+	NetworkAnalyticsMagicFirewallQuery,
+	NetworkAnalyticsMagicTransitQuery,
+	NetworkAnalyticsTcpProtectionQuery,
 	OriginStatusMetricsQuery,
 	RequestMethodMetricsQuery,
 	StreamLiveInputsQuery,
@@ -195,6 +200,12 @@ export class CloudflareMetricsClient {
 	// DataLoader for batched parallel REST calls (firewall rules benefit from
 	// batching in AccountMetricCoordinator where Promise.all fires multiple calls)
 	private readonly firewallRulesLoader: DataLoader<string, Map<string, string>>;
+
+	// Network-analytics datasets that returned an entitlement error
+	// ("does not have access to the path"). Cached in-memory per client instance
+	// so denied datasets are skipped on subsequent refreshes instead of wasting
+	// GraphQL rate-limit budget on a call that will always be denied.
+	private readonly deniedNetworkAnalyticsDatasets = new Set<string>();
 
 	constructor(config: CloudflareMetricsClientConfig) {
 		this.config = config;
@@ -1166,82 +1177,196 @@ export class CloudflareMetricsClient {
 		normalizedAccount: string,
 		timeRange: { mintime: string; maxtime: string },
 	): Promise<MetricDefinition[]> {
-		const result = await this.gql.query(NetworkAnalyticsQuery, {
+		const vars = {
 			accountID: accountId,
 			mintime: timeRange.mintime,
 			maxtime: timeRange.maxtime,
 			limit: this.config.queryLimit,
-		});
-
-		if (result.error) {
-			throw graphQLQueryError("network-analytics", result.error);
-		}
-
+		};
 		const metrics: MetricDefinition[] = [];
 
-		for (const accountData of result.data?.viewer?.accounts ?? []) {
-			// -- Magic Transit --
-			this.collectNetworkAnalyticsDataset(
-				accountData.magicTransitNetworkAnalyticsAdaptiveGroups ?? [],
-				"magic_transit",
-				"Magic Transit",
-				normalizedAccount,
-				metrics,
-				(dims) => ({
-					mitigation_system: dims.mitigationSystem ?? "",
-				}),
-			);
+		// Each NAv2 dataset is queried independently so a per-dataset
+		// authorization error (account not entitled to that product) does not
+		// null-bubble and discard the datasets the account IS entitled to.
 
-			// -- Magic Firewall --
-			this.collectNetworkAnalyticsDataset(
-				accountData.magicFirewallNetworkAnalyticsAdaptiveGroups ?? [],
-				"magic_firewall",
-				"Magic Firewall",
-				normalizedAccount,
-				metrics,
+		// -- Magic Transit --
+		if (this.shouldQueryNetworkAnalytics(accountId, "magic_transit")) {
+			const result = await this.gql.query(
+				NetworkAnalyticsMagicTransitQuery,
+				vars,
 			);
+			if (
+				this.handleNetworkAnalyticsResult(result, accountId, "magic_transit")
+			) {
+				for (const accountData of result.data?.viewer?.accounts ?? []) {
+					this.collectNetworkAnalyticsDataset(
+						accountData.magicTransitNetworkAnalyticsAdaptiveGroups ?? [],
+						"magic_transit",
+						"Magic Transit",
+						normalizedAccount,
+						metrics,
+						(dims) => ({
+							mitigation_system: dims.mitigationSystem ?? "",
+						}),
+					);
+				}
+			}
+		}
 
-			// -- DDoS Defense (dosd) --
-			this.collectNetworkAnalyticsDataset(
-				accountData.dosdNetworkAnalyticsAdaptiveGroups ?? [],
-				"dosd",
-				"DDoS defense",
-				normalizedAccount,
-				metrics,
-				(dims) => ({
-					attack_vector: dims.attackVector ?? "",
-				}),
+		// -- Magic Firewall --
+		if (this.shouldQueryNetworkAnalytics(accountId, "magic_firewall")) {
+			const result = await this.gql.query(
+				NetworkAnalyticsMagicFirewallQuery,
+				vars,
 			);
+			if (
+				this.handleNetworkAnalyticsResult(result, accountId, "magic_firewall")
+			) {
+				for (const accountData of result.data?.viewer?.accounts ?? []) {
+					this.collectNetworkAnalyticsDataset(
+						accountData.magicFirewallNetworkAnalyticsAdaptiveGroups ?? [],
+						"magic_firewall",
+						"Magic Firewall",
+						normalizedAccount,
+						metrics,
+					);
+				}
+			}
+		}
 
-			// -- IDPS --
-			this.collectNetworkAnalyticsDataset(
-				accountData.magicIDPSNetworkAnalyticsAdaptiveGroups ?? [],
-				"idps",
-				"Intrusion detection",
-				normalizedAccount,
-				metrics,
-			);
+		// -- DDoS Defense (dosd) --
+		if (this.shouldQueryNetworkAnalytics(accountId, "dosd")) {
+			const result = await this.gql.query(NetworkAnalyticsDosdQuery, vars);
+			if (this.handleNetworkAnalyticsResult(result, accountId, "dosd")) {
+				for (const accountData of result.data?.viewer?.accounts ?? []) {
+					this.collectNetworkAnalyticsDataset(
+						accountData.dosdNetworkAnalyticsAdaptiveGroups ?? [],
+						"dosd",
+						"DDoS defense",
+						normalizedAccount,
+						metrics,
+						(dims) => ({
+							attack_vector: dims.attackVector ?? "",
+						}),
+					);
+				}
+			}
+		}
 
-			// -- Advanced TCP Protection --
-			this.collectNetworkAnalyticsDataset(
-				accountData.advancedTcpProtectionNetworkAnalyticsAdaptiveGroups ?? [],
-				"tcp_protection",
-				"Advanced TCP protection",
-				normalizedAccount,
-				metrics,
-			);
+		// -- IDPS --
+		if (this.shouldQueryNetworkAnalytics(accountId, "idps")) {
+			const result = await this.gql.query(NetworkAnalyticsIDPSQuery, vars);
+			if (this.handleNetworkAnalyticsResult(result, accountId, "idps")) {
+				for (const accountData of result.data?.viewer?.accounts ?? []) {
+					this.collectNetworkAnalyticsDataset(
+						accountData.magicIDPSNetworkAnalyticsAdaptiveGroups ?? [],
+						"idps",
+						"Intrusion detection",
+						normalizedAccount,
+						metrics,
+					);
+				}
+			}
+		}
 
-			// -- Advanced DNS Protection --
-			this.collectNetworkAnalyticsDataset(
-				accountData.advancedDnsProtectionNetworkAnalyticsAdaptiveGroups ?? [],
-				"dns_protection",
-				"Advanced DNS protection",
-				normalizedAccount,
-				metrics,
+		// -- Advanced TCP Protection --
+		if (this.shouldQueryNetworkAnalytics(accountId, "tcp_protection")) {
+			const result = await this.gql.query(
+				NetworkAnalyticsTcpProtectionQuery,
+				vars,
 			);
+			if (
+				this.handleNetworkAnalyticsResult(result, accountId, "tcp_protection")
+			) {
+				for (const accountData of result.data?.viewer?.accounts ?? []) {
+					this.collectNetworkAnalyticsDataset(
+						accountData.advancedTcpProtectionNetworkAnalyticsAdaptiveGroups ??
+							[],
+						"tcp_protection",
+						"Advanced TCP protection",
+						normalizedAccount,
+						metrics,
+					);
+				}
+			}
+		}
+
+		// -- Advanced DNS Protection --
+		if (this.shouldQueryNetworkAnalytics(accountId, "dns_protection")) {
+			const result = await this.gql.query(
+				NetworkAnalyticsDnsProtectionQuery,
+				vars,
+			);
+			if (
+				this.handleNetworkAnalyticsResult(result, accountId, "dns_protection")
+			) {
+				for (const accountData of result.data?.viewer?.accounts ?? []) {
+					this.collectNetworkAnalyticsDataset(
+						accountData.advancedDnsProtectionNetworkAnalyticsAdaptiveGroups ??
+							[],
+						"dns_protection",
+						"Advanced DNS protection",
+						normalizedAccount,
+						metrics,
+					);
+				}
+			}
 		}
 
 		return metrics.filter((m) => m.values.length > 0);
+	}
+
+	/**
+	 * Whether a network-analytics dataset should be queried for an account.
+	 * Returns false if the dataset was previously denied (account not entitled),
+	 * so we don't waste GraphQL rate-limit budget re-querying it.
+	 *
+	 * @param accountId Cloudflare account ID.
+	 * @param slug Dataset slug (e.g. "magic_transit", "dosd").
+	 * @returns True if the dataset should be queried.
+	 */
+	private shouldQueryNetworkAnalytics(
+		accountId: string,
+		slug: string,
+	): boolean {
+		return !this.deniedNetworkAnalyticsDatasets.has(`${accountId}:${slug}`);
+	}
+
+	/**
+	 * Handles a per-dataset network-analytics query result.
+	 *
+	 * Returns true if the caller should collect metrics from `result.data`. On an
+	 * entitlement error ("does not have access to the path") the dataset is cached
+	 * as denied so it is skipped on subsequent refreshes. Transient errors (rate
+	 * limits, network) are logged but not cached, so they are retried next cycle.
+	 *
+	 * @param result GraphQL operation result (only `error` is inspected).
+	 * @param accountId Cloudflare account ID.
+	 * @param slug Dataset slug.
+	 * @returns True if metrics should be collected from the result.
+	 */
+	private handleNetworkAnalyticsResult(
+		result: { error?: { message: string } | null },
+		accountId: string,
+		slug: string,
+	): boolean {
+		if (result.error) {
+			if (result.error.message.includes("does not have access to the path")) {
+				this.deniedNetworkAnalyticsDatasets.add(`${accountId}:${slug}`);
+				this.logger.info(
+					"Network analytics dataset not available for account; skipping",
+					{ account_id: accountId, dataset: slug },
+				);
+			} else {
+				this.logger.warn("Network analytics dataset query failed", {
+					account_id: accountId,
+					dataset: slug,
+					error: result.error.message,
+				});
+			}
+			return false;
+		}
+		return true;
 	}
 
 	/**

--- a/src/cloudflare/gql/queries.ts
+++ b/src/cloudflare/gql/queries.ts
@@ -809,12 +809,18 @@ export const CacheMissMetricsQuery = graphql(`
 `);
 
 /**
- * Combined network analytics query across all 6 NAv2 datasets.
- * Returns bits/packets totals with low-cardinality dimensions.
- * Datasets that don't apply to an account return empty arrays.
+ * Per-dataset network analytics queries (one GraphQL query per NAv2 dataset).
+ *
+ * These were previously a single combined query. Cloudflare's GraphQL API
+ * null-bubbles a per-dataset authorization error ("does not have access to the
+ * path") up to the nullable `viewer` field, so if an account is not entitled to
+ * ANY one dataset (e.g. Advanced TCP/DNS Protection), the entire combined
+ * response is nulled and every dataset is lost — including the ones the account
+ * IS entitled to. Querying each dataset independently isolates the denial so
+ * entitled datasets still return data.
  */
-export const NetworkAnalyticsQuery = graphql(`
-  query NetworkAnalytics(
+export const NetworkAnalyticsMagicTransitQuery = graphql(`
+  query NetworkAnalyticsMagicTransit(
     $accountID: string!
     $limit: uint64!
     $mintime: Time!
@@ -837,6 +843,20 @@ export const NetworkAnalyticsQuery = graphql(`
             mitigationSystem
           }
         }
+      }
+    }
+  }
+`);
+
+export const NetworkAnalyticsMagicFirewallQuery = graphql(`
+  query NetworkAnalyticsMagicFirewall(
+    $accountID: string!
+    $limit: uint64!
+    $mintime: Time!
+    $maxtime: Time!
+  ) {
+    viewer {
+      accounts(filter: { accountTag: $accountID }) {
         magicFirewallNetworkAnalyticsAdaptiveGroups(
           limit: $limit
           filter: { datetime_geq: $mintime, datetime_lt: $maxtime }
@@ -851,6 +871,20 @@ export const NetworkAnalyticsQuery = graphql(`
             ipProtocolName
           }
         }
+      }
+    }
+  }
+`);
+
+export const NetworkAnalyticsDosdQuery = graphql(`
+  query NetworkAnalyticsDosd(
+    $accountID: string!
+    $limit: uint64!
+    $mintime: Time!
+    $maxtime: Time!
+  ) {
+    viewer {
+      accounts(filter: { accountTag: $accountID }) {
         dosdNetworkAnalyticsAdaptiveGroups(
           limit: $limit
           filter: { datetime_geq: $mintime, datetime_lt: $maxtime }
@@ -866,6 +900,20 @@ export const NetworkAnalyticsQuery = graphql(`
             attackVector
           }
         }
+      }
+    }
+  }
+`);
+
+export const NetworkAnalyticsIDPSQuery = graphql(`
+  query NetworkAnalyticsIDPS(
+    $accountID: string!
+    $limit: uint64!
+    $mintime: Time!
+    $maxtime: Time!
+  ) {
+    viewer {
+      accounts(filter: { accountTag: $accountID }) {
         magicIDPSNetworkAnalyticsAdaptiveGroups(
           limit: $limit
           filter: { datetime_geq: $mintime, datetime_lt: $maxtime }
@@ -880,6 +928,20 @@ export const NetworkAnalyticsQuery = graphql(`
             ipProtocolName
           }
         }
+      }
+    }
+  }
+`);
+
+export const NetworkAnalyticsTcpProtectionQuery = graphql(`
+  query NetworkAnalyticsTcpProtection(
+    $accountID: string!
+    $limit: uint64!
+    $mintime: Time!
+    $maxtime: Time!
+  ) {
+    viewer {
+      accounts(filter: { accountTag: $accountID }) {
         advancedTcpProtectionNetworkAnalyticsAdaptiveGroups(
           limit: $limit
           filter: { datetime_geq: $mintime, datetime_lt: $maxtime }
@@ -894,6 +956,20 @@ export const NetworkAnalyticsQuery = graphql(`
             ipProtocolName
           }
         }
+      }
+    }
+  }
+`);
+
+export const NetworkAnalyticsDnsProtectionQuery = graphql(`
+  query NetworkAnalyticsDnsProtection(
+    $accountID: string!
+    $limit: uint64!
+    $mintime: Time!
+    $maxtime: Time!
+  ) {
+    viewer {
+      accounts(filter: { accountTag: $accountID }) {
         advancedDnsProtectionNetworkAnalyticsAdaptiveGroups(
           limit: $limit
           filter: { datetime_geq: $mintime, datetime_lt: $maxtime }


### PR DESCRIPTION
## Problem

For accounts entitled to *some but not all* Network Analytics (NAv2) datasets, the exporter returns **zero** NAv2 metrics — even for datasets the account is fully entitled to. See issue #44.

`getAccountMetrics("network-analytics")` issues a single combined GraphQL query that selects six NAv2 datasets in one `viewer { accounts { … } }` document (magicTransit, magicFirewall, dosd/L3 DoS, advanced TCP protection, advanced DNS protection, IDPS). If the account lacks entitlement to **any one** of them, the GraphQL API returns an authorization error on that non-nullable field, which **null-bubbles** up to `data.viewer` and nulls the entire response — so entitled datasets (e.g. Magic Transit) come back empty too.

## Fix

Split the combined query into one query per NAv2 dataset and collect them independently, so a denial on one dataset can no longer null-bubble the others. Denied datasets are remembered and skipped on subsequent refreshes; entitled datasets continue to return metrics.

## Changes

- `src/cloudflare/gql/queries.ts`: split the combined query into six per-dataset queries
- `src/cloudflare/client.ts`: collect each NAv2 dataset independently with a per-dataset denied-cache and soft-handling of access-denied responses
- `src/cloudflare/client.test.ts`: cover partial entitlement (some datasets denied, others returned) instead of expecting the whole refresh to throw

## Verification

- `bun run check` (biome) clean
- `bun run typecheck` clean
- `bun run test` — full suite passes
