### PR TITLE
feat: add hostname cache status by content type

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,6 +429,7 @@ All hostname metrics are **gauge snapshots** of the **last completed minute**, d
 | `cloudflare_zone_hostname_requests` | gauge | zone, host | Total requests in the last completed minute |
 | `cloudflare_zone_hostname_requests_by_status` | gauge | zone, host, status | Requests by HTTP status code |
 | `cloudflare_zone_hostname_cache_status` | gauge | zone, host, cache_status | Requests by cache status (hit/miss/etc.) |
+| `cloudflare_zone_hostname_content_cache_status` | gauge | zone, host, content_type, cache_status | Requests by cache status broken down by response content type (e.g. json, html) |
 
 **Latency (averages — primary alerting metrics):**
 

--- a/src/cloudflare/client.ts
+++ b/src/cloudflare/client.ts
@@ -2629,6 +2629,12 @@ export class CloudflareMetricsClient {
 			type: "gauge",
 			values: [],
 		};
+		const hostnameContentCacheStatus: MetricDefinition = {
+			name: "cloudflare_zone_hostname_content_cache_status",
+			help: "Requests per hostname by cache status and response content type in the last completed minute",
+			type: "gauge",
+			values: [],
+		};
 		const hostnameEdgeTtfb: MetricDefinition = {
 			name: "cloudflare_zone_hostname_edge_ttfb_seconds",
 			help: "Average edge time to first byte per hostname in seconds (last completed minute)",
@@ -2721,6 +2727,28 @@ export class CloudflareMetricsClient {
 				}
 			}
 
+			// Requests by cache status and response content type per host
+			for (const group of zoneData.hostContentCache ?? []) {
+				const host = (
+					group.dimensions?.clientRequestHTTPHost ?? ""
+				).toLowerCase();
+				const cacheStatus = group.dimensions?.cacheStatus ?? "";
+				const contentType =
+					group.dimensions?.edgeResponseContentTypeName ?? "";
+				const count = group.count ?? 0;
+				if (count > 0) {
+					hostnameContentCacheStatus.values.push({
+						labels: {
+							zone: zoneName,
+							host,
+							content_type: contentType,
+							cache_status: cacheStatus,
+						},
+						value: count,
+					});
+				}
+			}
+
 			// Latency per host: averages (primary alerting metric) + percentiles (separate families)
 			for (const group of zoneData.hostLatency ?? []) {
 				const host = (
@@ -2781,6 +2809,10 @@ export class CloudflareMetricsClient {
 				{ name: "hostRequests", len: zoneData.hostRequests?.length ?? 0 },
 				{ name: "hostStatus", len: zoneData.hostStatus?.length ?? 0 },
 				{ name: "hostCache", len: zoneData.hostCache?.length ?? 0 },
+				{
+					name: "hostContentCache",
+					len: zoneData.hostContentCache?.length ?? 0,
+				},
 				{ name: "hostLatency", len: zoneData.hostLatency?.length ?? 0 },
 			];
 			for (const alias of aliases) {
@@ -2816,6 +2848,7 @@ export class CloudflareMetricsClient {
 			hostnameRequests,
 			hostnameStatus,
 			hostnameCacheStatus,
+			hostnameContentCacheStatus,
 			hostnameEdgeTtfb,
 			hostnameEdgeTtfbP50,
 			hostnameEdgeTtfbP95,

--- a/src/cloudflare/gql/queries.ts
+++ b/src/cloudflare/gql/queries.ts
@@ -749,6 +749,22 @@ export const HostnameHttpMetricsQuery = graphql(`
           }
         }
 
+        hostContentCache: httpRequestsAdaptiveGroups(
+          limit: $limit
+          filter: {
+            datetime_geq: $mintime
+            datetime_lt: $maxtime
+            clientRequestHTTPHost_in: $hosts
+          }
+        ) {
+          count
+          dimensions {
+            clientRequestHTTPHost
+            cacheStatus
+            edgeResponseContentTypeName
+          }
+        }
+
         hostLatency: httpRequestsAdaptiveGroups(
           limit: $limit
           filter: {


### PR DESCRIPTION
Adds cloudflare_zone_hostname_content_cache_status{zone, host, content_type, cache_status} via a new hostContentCache alias on HostnameHttpMetricsQuery (edgeResponseContentTypeName dimension). Purely additive; existing cloudflare_zone_hostname_cache_status is unchanged. Reuses HOST_METRICS_ALLOWLIST opt-in. Closes #47
