### PR TITLE
fix: don't block account-scoped refresh on zero-zone accounts

### DIFF
--- a/src/durable-objects/MetricExporter.ts
+++ b/src/durable-objects/MetricExporter.ts
@@ -231,8 +231,9 @@ export class MetricExporter extends DurableObject<Env> {
 			return;
 		}
 
-		const isFirstContext =
-			state.zones.length === 0 && zones.length > 0 && state.lastRefresh === 0;
+		// accountId === "" means this is genuinely the first context push, as
+		// opposed to a legitimate zero-zone account (e.g. Magic Transit-only).
+		const isFirstContext = state.accountId === "" && state.lastRefresh === 0;
 
 		const updatedState: MetricExporterState = {
 			...state,
@@ -349,9 +350,11 @@ export class MetricExporter extends DurableObject<Env> {
 	): Promise<void> {
 		const state = this.getState();
 
-		// Skip if zone context not yet pushed (account-scoped needs zones)
-		if (state.scopeType === "account" && state.zones.length === 0) {
-			logger.info("Skipping refresh - no zone context yet");
+		// Skip if account context not yet pushed. Checks accountId rather than
+		// zones.length so account-level-only queries (e.g. magic-transit) still
+		// run for accounts with zero zones.
+		if (state.scopeType === "account" && state.accountId === "") {
+			logger.info("Skipping refresh - no account context yet");
 			await this.scheduleNextAlarm(config);
 			return;
 		}


### PR DESCRIPTION
## Problem

`MetricExporter.refreshWithTimeRange` and `updateZoneContext` gate account-scoped refresh on `state.zones.length === 0`, using it as a proxy for "context not yet initialized."

Magic Transit-only accounts (or any account where the token can't list zones, or the account simply has none) can legitimately have zero zones. For these accounts, this check is permanently true, so `isFirstContext` never fires and every subsequent alarm hits the "no zone context yet" skip - meaning **every account-level query** (`magic-transit`, `magic-transit-slo`, `magic-transit-traffic`, `magic-firewall-samples`, `worker-totals`, `logpush-account`, `images`) silently never runs for that account, even though none of these queries use zone data at all.

Found while debugging why Magic Transit metrics were completely absent (not just wrong) for a zero-zone account - `/metrics` showed `cloudflare_accounts 1` but nothing else, and Worker logs showed `"Skipping refresh - no account context yet"`/`"Skipping refresh - no zone context yet"` repeating indefinitely.

## Fix

Track "has this exporter ever received a context push" via `accountId === ""` (the actual uninitialized-state sentinel already used elsewhere in `MetricExporterState`) instead of `zones.length === 0`, in both the `isFirstContext` check in `updateZoneContext` and the skip-gate in `refreshWithTimeRange`. This correctly distinguishes "never initialized" from "initialized with zero zones," and has no effect on accounts that do have zones.

## Testing

- `tsc --noEmit` and `vitest run` (56 existing tests) pass.
- `biome check` clean.
- Verified live on a deployed Worker against a zero-zone Magic Transit account: before this fix, no account-level metrics ever appeared; after, `magic-transit`/`magic-transit-traffic`/`magic-firewall-samples` all populate correctly on schedule.
