### PR TITLE
fix: respect HTTP status grouping config

### DIFF
--- a/src/cloudflare/client.test.ts
+++ b/src/cloudflare/client.test.ts
@@ -62,6 +62,80 @@ describe("CloudflareMetricsClient", () => {
 	});
 
 	it.each([
+		{
+			httpStatusGroup: false,
+			expected: [
+				{ labels: { status: "200", zone: "example.com" }, value: 3 },
+				{ labels: { status: "204", zone: "example.com" }, value: 2 },
+			],
+		},
+		{
+			httpStatusGroup: true,
+			expected: [{ labels: { status: "2xx", zone: "example.com" }, value: 5 }],
+		},
+	])("respects HTTP status grouping when set to $httpStatusGroup", async ({
+		httpStatusGroup,
+		expected,
+	}) => {
+		const fetch: typeof globalThis.fetch = async () =>
+			new Response(
+				JSON.stringify({
+					data: {
+						viewer: {
+							zones: [
+								{
+									zoneTag: "zone-id",
+									httpRequests1mGroups: [
+										{
+											sum: {
+												requests: 5,
+												responseStatusMap: [
+													{ edgeResponseStatus: 200, requests: 3 },
+													{ edgeResponseStatus: 204, requests: 2 },
+												],
+											},
+										},
+									],
+									firewallEventsAdaptiveGroups: [],
+								},
+							],
+						},
+					},
+				}),
+				{ headers: { "content-type": "application/json" } },
+			);
+		const client = createClient(fetch);
+
+		const metrics = await client.getZoneMetrics(
+			"http-metrics",
+			["zone-id"],
+			[
+				{
+					id: "zone-id",
+					name: "example.com",
+					status: "active",
+					plan: { id: "paid", name: "Paid" },
+					account: { id: "account-id", name: "Account" },
+				},
+			],
+			{},
+			{
+				mintime: "2026-01-01T00:00:00.000Z",
+				maxtime: "2026-01-01T00:01:00.000Z",
+			},
+			undefined,
+			undefined,
+			httpStatusGroup,
+		);
+
+		expect(
+			metrics.find(
+				(metric) => metric.name === "cloudflare_zone_requests_status_total",
+			)?.values,
+		).toEqual(expected);
+	});
+
+	it.each([
 		"http-metrics",
 		"adaptive-metrics",
 		"edge-country-metrics",

--- a/src/cloudflare/client.ts
+++ b/src/cloudflare/client.ts
@@ -1499,6 +1499,7 @@ export class CloudflareMetricsClient {
 	 * @param timeRange Shared time range for query alignment.
 	 * @param hostMetricsAllowlist Allowed hostnames for hostname-http-metrics query.
 	 * @param hostMetricsDelaySeconds Ingestion delay override for hostname metrics.
+	 * @param httpStatusGroup Whether to group HTTP response statuses by class.
 	 * @returns Promise of metric definitions for the zones.
 	 * @throws {Error} When unknown query type provided.
 	 */
@@ -1510,6 +1511,7 @@ export class CloudflareMetricsClient {
 		timeRange: TimeRange,
 		hostMetricsAllowlist?: ReadonlySet<string>,
 		hostMetricsDelaySeconds?: number,
+		httpStatusGroup = false,
 	): Promise<MetricDefinition[]> {
 		this.logger.info("Fetching zone metrics", {
 			query,
@@ -1523,6 +1525,7 @@ export class CloudflareMetricsClient {
 					zones,
 					firewallMap,
 					timeRange,
+					httpStatusGroup,
 				);
 			case "adaptive-metrics":
 				return this.getAdaptiveMetrics(zoneIds, zones, timeRange);
@@ -1571,6 +1574,7 @@ export class CloudflareMetricsClient {
 	 * @param zones Zone metadata for label mapping.
 	 * @param firewallRules Map of rule IDs to names for labels.
 	 * @param timeRange Time range for the query.
+	 * @param httpStatusGroup Whether to group HTTP response statuses by class.
 	 * @returns HTTP metrics.
 	 * @throws {Error} When GraphQL query fails.
 	 */
@@ -1579,6 +1583,7 @@ export class CloudflareMetricsClient {
 		zones: Zone[],
 		firewallRules: Map<string, string>,
 		timeRange: TimeRange,
+		httpStatusGroup: boolean,
 	): Promise<MetricDefinition[]> {
 		const queryVars = {
 			zoneIDs: zoneIds,
@@ -1644,7 +1649,9 @@ export class CloudflareMetricsClient {
 		};
 		const requestsStatus: MetricDefinition = {
 			name: "cloudflare_zone_requests_status_total",
-			help: "Requests by status code group",
+			help: httpStatusGroup
+				? "Requests by status code group"
+				: "Requests by status code",
 			type: "counter",
 			values: [],
 		};
@@ -1860,12 +1867,14 @@ export class CloudflareMetricsClient {
 				}
 			}
 
-			// Status code breakdown (with grouping)
+			// Status code breakdown
 			const statusGroups: Record<string, number> = {};
 			for (const s of sum?.responseStatusMap ?? []) {
-				const groupedStatus = groupStatusCode(s.edgeResponseStatus ?? 0);
-				statusGroups[groupedStatus] =
-					(statusGroups[groupedStatus] ?? 0) + (s.requests ?? 0);
+				const statusCode = s.edgeResponseStatus ?? 0;
+				const status = httpStatusGroup
+					? groupStatusCode(statusCode)
+					: String(statusCode);
+				statusGroups[status] = (statusGroups[status] ?? 0) + (s.requests ?? 0);
 			}
 			for (const [status, count] of Object.entries(statusGroups)) {
 				requestsStatus.values.push({

--- a/src/durable-objects/MetricExporter.ts
+++ b/src/durable-objects/MetricExporter.ts
@@ -594,6 +594,7 @@ export class MetricExporter extends DurableObject<Env> {
 						timeRange,
 						hostMetricsAllowlist,
 						hostMetricsDelaySeconds,
+						config.httpStatusGroup,
 					),
 					partialErrors: [],
 					failedScopes: new Set(),
@@ -639,6 +640,7 @@ export class MetricExporter extends DurableObject<Env> {
 						timeRange,
 						hostMetricsAllowlist,
 						hostMetricsDelaySeconds,
+						config.httpStatusGroup,
 					);
 					for (const zoneId of chunkIds) delete zoneRetryAfter[zoneId];
 					chunkResults.push(metrics);


### PR DESCRIPTION
## Summary
- pass the resolved `httpStatusGroup` setting through zone metric fetches
- emit exact status-code labels when disabled and grouped `x00` labels when enabled
- add regression coverage for both modes

## Testing
- `npm run check`
- `npm test`
- `npm run typecheck`