### PR TITLE
fix: restore Magic Transit active tunnel metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,7 @@ curl -X DELETE https://your-worker.workers.dev/config
 
 | Metric | Type | Labels |
 |--------|------|--------|
+| `cloudflare_magic_transit_active_tunnels` | gauge | account, tunnel_name, site_name |
 | `cloudflare_magic_transit_healthy_tunnels` | gauge | account, tunnel_name, site_name |
 | `cloudflare_magic_transit_tunnel_failures` | gauge | account, tunnel_name, site_name |
 | `cloudflare_magic_transit_edge_colo_count` | gauge | account, tunnel_name, site_name |

--- a/src/cloudflare/client.test.ts
+++ b/src/cloudflare/client.test.ts
@@ -61,6 +61,69 @@ describe("CloudflareMetricsClient", () => {
 		).resolves.toEqual([]);
 	});
 
+	it("reports active Magic Transit tunnel health checks", async () => {
+		const fetch: typeof globalThis.fetch = async () =>
+			new Response(
+				JSON.stringify({
+					data: {
+						viewer: {
+							accounts: [
+								{
+									magicTransitTunnelHealthChecksAdaptiveGroups: [
+										{
+											count: 3,
+											dimensions: {
+												active: 1,
+												resultStatus: "ok",
+												siteName: "site",
+												tunnelName: "tunnel",
+											},
+										},
+										{
+											count: 2,
+											dimensions: {
+												active: 0,
+												resultStatus: "timeout",
+												siteName: "site",
+												tunnelName: "tunnel",
+											},
+										},
+									],
+								},
+							],
+						},
+					},
+				}),
+				{ headers: { "content-type": "application/json" } },
+			);
+		const client = createClient(fetch);
+
+		const metrics = await client.getAccountMetrics(
+			"magic-transit",
+			"account-id",
+			"Account",
+			{
+				mintime: "2026-01-01T00:00:00.000Z",
+				maxtime: "2026-01-01T00:01:00.000Z",
+			},
+		);
+
+		expect(
+			metrics.find(
+				(metric) => metric.name === "cloudflare_magic_transit_active_tunnels",
+			)?.values,
+		).toEqual([
+			{
+				labels: {
+					account: "account",
+					site_name: "site",
+					tunnel_name: "tunnel",
+				},
+				value: 3,
+			},
+		]);
+	});
+
 	it.each([
 		{
 			httpStatusGroup: false,

--- a/src/cloudflare/client.ts
+++ b/src/cloudflare/client.ts
@@ -732,6 +732,12 @@ export class CloudflareMetricsClient {
 			throw graphQLQueryError("magic-transit", result.error);
 		}
 
+		const activeTunnels: MetricDefinition = {
+			name: "cloudflare_magic_transit_active_tunnels",
+			help: "Active Magic Transit tunnels",
+			type: "gauge",
+			values: [],
+		};
 		const healthyTunnels: MetricDefinition = {
 			name: "cloudflare_magic_transit_healthy_tunnels",
 			help: "Healthy Magic Transit tunnels",
@@ -808,6 +814,11 @@ export class CloudflareMetricsClient {
 						site_name: siteName,
 					};
 
+					const active = tunnelGroups
+						.filter((g) => (g.dimensions?.active ?? 0) === 1)
+						.reduce((sum, g) => sum + (g.count ?? 0), 0);
+					if (active > 0) activeTunnels.values.push({ labels, value: active });
+
 					// Healthy: resultStatus === "ok" (the API never returns "healthy")
 					const healthy = tunnelGroups
 						.filter((g) => g.dimensions?.resultStatus === "ok")
@@ -874,6 +885,7 @@ export class CloudflareMetricsClient {
 		}
 
 		return [
+			activeTunnels,
 			healthyTunnels,
 			tunnelFailures,
 			edgeColoCount,

--- a/src/cloudflare/gql/queries.ts
+++ b/src/cloudflare/gql/queries.ts
@@ -540,6 +540,7 @@ export const MagicTransitMetricsQuery = graphql(`
             tunnelState
           }
           dimensions {
+            active
             datetime
             edgeColoCity
             edgeColoCountry


### PR DESCRIPTION
## Summary

- restore the `active` dimension to `MagicTransitMetricsQuery`
- reintroduce `cloudflare_magic_transit_active_tunnels`
- add regression coverage for active/inactive health-check aggregation
- restore the metric documentation

## Verification

The `active` dimension was removed in #49 because including it caused `magicTransitTunnelHealthChecksAdaptiveGroups` to return zero rows. A live GraphQL comparison on 2026-08-26 now succeeds both with and without the dimension:

| Query | Rows | GraphQL errors |
|---|---:|---:|
| Without `active` | 10,000 | 0 |
| With `active` | 10,000 | 0 |

The response with `active` contained both `0` and `1` values, confirming the field is populated again. This keeps #49’s separate correction from `resultStatus === "healthy"` to `resultStatus === "ok"`.

## Testing

- `npx --no-install biome check`
- `npx --no-install tsc --noEmit`
- `npx --no-install vitest run` (59 tests)