### PR TITLE
feat: expose SSL certificate leaf details

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,7 +449,9 @@ All hostname metrics are **gauge snapshots** of the **last completed minute**, d
 
 | Metric | Type | Labels |
 |--------|------|--------|
-| `cloudflare_zone_certificate_validation_status` | gauge | zone, type, issuer, status |
+| `cloudflare_zone_certificate_validation_status` | gauge | zone, certificate_id, hosts, signature_algorithm, type, issuer, status |
+
+The certificate metric value is the expiry time as a Unix timestamp. The `hosts` label contains the certificate's sorted, comma-separated hostnames/SANs. The `signature_algorithm` label distinguishes RSA and ECDSA certificates while retaining the hash algorithm reported by Cloudflare.
 
 ### Exporter Info Metrics
 

--- a/src/cloudflare/client.test.ts
+++ b/src/cloudflare/client.test.ts
@@ -61,6 +61,60 @@ describe("CloudflareMetricsClient", () => {
 		).resolves.toEqual([]);
 	});
 
+	it("identifies SSL certificates by ID and sorted SANs", async () => {
+		const fetch: typeof globalThis.fetch = async () =>
+			new Response(
+				JSON.stringify({
+					success: true,
+					errors: [],
+					messages: [],
+					result: [
+						{
+							id: "pack-id",
+							type: "sni_custom",
+							status: "active",
+							primary_certificate: "certificate-id",
+							hosts: ["example.com", "*.example.com"],
+							certificates: [
+								{
+									id: "certificate-id",
+									issuer: "Test CA",
+									status: "active",
+									expires_on: "2027-01-01T00:00:00.000Z",
+									signature: "ECDSAWithSHA256",
+								},
+							],
+						},
+					],
+				}),
+				{ headers: { "content-type": "application/json" } },
+			);
+		const client = createClient(fetch);
+
+		const metrics = await client.getSSLCertificateMetricsForZone({
+			id: "zone-id",
+			name: "example.com",
+			status: "active",
+			plan: { id: "paid", name: "Paid" },
+			account: { id: "account-id", name: "Account" },
+		});
+
+		expect(metrics[0]?.values).toEqual([
+			{
+				labels: {
+					zone: "example.com",
+					certificate_id: "certificate-id",
+					hosts: "*.example.com,example.com",
+					signature_algorithm: "ECDSAWithSHA256",
+					type: "sni_custom",
+					issuer: "Test CA",
+					status: "active",
+				},
+				value: 1798761600,
+			},
+		]);
+	});
+
 	it.each([
 		{
 			httpStatusGroup: false,

--- a/src/cloudflare/client.ts
+++ b/src/cloudflare/client.ts
@@ -410,6 +410,7 @@ export class CloudflareMetricsClient {
 				issuer: z.string().optional(),
 				status: z.string().optional(),
 				expires_on: z.string().optional(),
+				signature: z.string().optional(),
 			})
 			.passthrough();
 
@@ -446,6 +447,7 @@ export class CloudflareMetricsClient {
 						status: certData.status ?? pack.status ?? "",
 						issuer: certData.issuer ?? "unknown",
 						expiresOn: certData.expires_on ?? "",
+						signatureAlgorithm: certData.signature ?? "unknown",
 						hosts: pack.hosts,
 					});
 				}
@@ -3293,6 +3295,9 @@ export class CloudflareMetricsClient {
 				certStatus.values.push({
 					labels: {
 						zone: zone.name,
+						certificate_id: cert.id,
+						hosts: cert.hosts.toSorted().join(","),
+						signature_algorithm: cert.signatureAlgorithm,
 						type: cert.type,
 						issuer: cert.issuer,
 						status: cert.status,
@@ -3335,6 +3340,9 @@ export class CloudflareMetricsClient {
 				certStatus.values.push({
 					labels: {
 						zone: zone.name,
+						certificate_id: cert.id,
+						hosts: cert.hosts.toSorted().join(","),
+						signature_algorithm: cert.signatureAlgorithm,
 						type: cert.type,
 						issuer: cert.issuer,
 						status: cert.status,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -134,6 +134,7 @@ export const SSLCertificateSchema = z
 		status: z.string(),
 		issuer: z.string(),
 		expiresOn: z.string(),
+		signatureAlgorithm: z.string(),
 		hosts: z.array(z.string()),
 	})
 	.readonly();


### PR DESCRIPTION
## Summary
- add certificate ID and sorted SAN list to SSL certificate metrics
- expose the Cloudflare signature algorithm to distinguish RSA and ECDSA certificates
- document the expanded labels and certificate expiry timestamp value
- add coverage for certificate leaf labels and deterministic SAN ordering

## Testing
- `npm test`
- `npm run typecheck`
- `npm run check`